### PR TITLE
동네 관련 API에 대한 피드백 반영 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/ApiResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/ApiResponse.java
@@ -22,4 +22,9 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
 		return new ApiResponse<>(status, message, data);
 	}
+
+	public static <T> ApiResponse<T> noData(HttpStatus status, String message) {
+		return new ApiResponse<>(status, message, null);
+	}
+
 }

--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -7,9 +7,9 @@ public enum ResponseMessage {
 
 	CATEGORY_FETCH_SUCCESS("카테고리 목록 조회를 성공하였습니다."),
 	REGION_FETCH_SUCCESS("동네 목록 조회를 성공하였습니다."),
-	USER_REGION_FETCH_SUCCESS("나의 동네 목록 조회를 성공하였습니다."),
-	USER_REGION_CREATE_SUCCESS("나의 동네 목록 등록을 성공하였습니다."),
-	USER_REGION_DELETE_SUCCESS("나의 동네 목록 삭제를 성공하였습니다.");
+	USER_REGION_FETCH_SUCCESS("나의 동네 조회를 성공하였습니다."),
+	USER_REGION_CREATE_SUCCESS("나의 동네 등록을 성공하였습니다."),
+	USER_REGION_DELETE_SUCCESS("나의 동네 삭제를 성공하였습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
@@ -39,7 +39,7 @@ public class UserRegionController {
 	public ApiResponse<Void> createUserRegion(@RequestBody UserRegionCreateRequest request) {
 		final Long userId = 1L;
 		userRegionService.createUserRegion(request.toService(userId));
-		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REGION_CREATE_SUCCESS.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.USER_REGION_CREATE_SUCCESS.getMessage());
 	}
 
 	@ResponseStatus(HttpStatus.NO_CONTENT)
@@ -47,7 +47,7 @@ public class UserRegionController {
 	public ApiResponse<Void> deleteUserRegion(@PathVariable Long id) {
 		final Long userId = 1L;
 		userRegionService.deleteUserRegion(userId, id);
-		return ApiResponse.of(HttpStatus.NO_CONTENT, ResponseMessage.USER_REGION_DELETE_SUCCESS.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.NO_CONTENT, ResponseMessage.USER_REGION_DELETE_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/MyRegion.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/MyRegion.java
@@ -43,7 +43,7 @@ public class MyRegion {
 	}
 
 	private void validateUserRegionLimit() {
-		if (this.userRegions.size() == MAXIMUM_USER_REGION_COUNT) {
+		if (this.userRegions.size() >= MAXIMUM_USER_REGION_COUNT) {
 			throw new ExceedUserRegionLimitException();
 		}
 	}
@@ -55,7 +55,7 @@ public class MyRegion {
 	}
 
 	private void validateMinimumUserRegion() {
-		if (this.userRegions.size() == MINIMUM_USER_REGION_COUNT) {
+		if (this.userRegions.size() <= MINIMUM_USER_REGION_COUNT) {
 			throw new MinimumUserRegionViolationException();
 		}
 	}

--- a/src/main/java/com/codesquad/secondhand/exception/common/CommonExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/common/CommonExceptionHandler.java
@@ -13,7 +13,7 @@ public class CommonExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InvalidCursorException.class)
 	public ApiResponse<Void> handleUserRegionException(InvalidCursorException exception) {
-		return ApiResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/region/RegionExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/region/RegionExceptionHandler.java
@@ -13,7 +13,7 @@ public class RegionExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(NoSuchRegionException.class)
 	public ApiResponse<Void> handleNoSuchRegionException(NoSuchRegionException exception) {
-		return ApiResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user/UserExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user/UserExceptionHandler.java
@@ -13,7 +13,7 @@ public class UserExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(NoSuchUserException.class)
 	public ApiResponse<Void> handleNoSuchUserException(NoSuchUserException exception) {
-		return ApiResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user_region/UserRegionExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user_region/UserRegionExceptionHandler.java
@@ -14,7 +14,7 @@ public class UserRegionExceptionHandler {
 	@ExceptionHandler({ExceedUserRegionLimitException.class, MinimumUserRegionViolationException.class,
 		DuplicatedUserRegionException.class, NoSuchUserRegionException.class})
 	public ApiResponse<Void> handleUserRegionException(RuntimeException exception) {
-		return ApiResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage(), null);
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
 	}
 
 }


### PR DESCRIPTION
## Description

- API 성공 메세지를 수정했습니다.
- data가 비어있음을 명시하는 ApiResponse 팩토리 메서드를 추가했습니다.
- `==` 연산자를 `>=` 로 변경했습니다.

### Considerations
- 추후에 User 테이블 및 Entity 객체의 수정이 필요합니다.
- 예외 처리 메세지 관리를 위한 Enum을 생성합니다.

## Next Step

- 사용자 회원가입 / 로그인 구현을 진행합니다.

Closes #25 