### PR TITLE
동네 목록 조회 API에 검색 기능 추가 구현 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/controller/region/RegionController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/region/RegionController.java
@@ -22,8 +22,11 @@ public class RegionController {
 	private final RegionService regionService;
 
 	@GetMapping
-	public ApiResponse<RegionSliceResponse> listAllRegions(@RequestParam Cursor cursor) {
+	public ApiResponse<RegionSliceResponse> listAllRegions(
+		@RequestParam(required = false, defaultValue = "") String title,
+		@RequestParam Cursor cursor) {
 		return ApiResponse.of(HttpStatus.OK, ResponseMessage.REGION_FETCH_SUCCESS.getMessage(),
-			regionService.listAllRegions(cursor.getCursor()));
+			regionService.listAllRegions(title, cursor.getCursor()));
 	}
+
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/region/RegionService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/region/RegionService.java
@@ -24,9 +24,9 @@ public class RegionService {
 	private final RegionRepository regionRepository;
 
 	@Transactional(readOnly = true)
-	public RegionSliceResponse listAllRegions(final int cursor) {
+	public RegionSliceResponse listAllRegions(String title, int cursor) {
 		final Pageable pageable = PageRequest.of(cursor, REGION_PER_PAGE);
-		final Slice<Region> regions = regionRepository.findSliceBy(pageable);
+		final Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, title);
 
 		return new RegionSliceResponse(regions.hasNext(), regions
 			.stream()

--- a/src/main/java/com/codesquad/secondhand/domain/region/RegionRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/region/RegionRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<Region, Long> {
 
-	Slice<Region> findSliceBy(Pageable pageable);
+	Slice<Region> findSliceByTitleContaining(Pageable pageable, String title);
 
 }

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -18,13 +18,19 @@ public abstract class FixtureFactory {
 			.collect(Collectors.toList());
 	}
 
+	public static List<Region> createRegionFixtures(int size, String title) {
+		return IntStream.rangeClosed(1, size)
+			.mapToObj(i -> new Region(null, title + i))
+			.collect(Collectors.toList());
+	}
+
 	public static User createUserFixtureWithRegions(List<Region> regions) {
 		User user = new User(null, "nickname", "test@email.com", "password123!", null,
 			LocalDateTime.of(2023, 9, 1, 12, 0), new MyRegion());
 		regions.forEach(user::addUserRegion);
 		return user;
-  }
-  
+	}
+
 	public static List<Category> createCategoryFixture(int size) {
 		return IntStream.rangeClosed(1, size)
 			.mapToObj(i -> new Category((long)i, "category" + i, "http://url" + i + ".com"))

--- a/src/test/java/com/codesquad/secondhand/api/service/region/RegionServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/region/RegionServiceTest.java
@@ -17,6 +17,8 @@ import com.codesquad.secondhand.domain.user_region.UserRegionRepository;
 
 class RegionServiceTest extends IntegrationTestSupport {
 
+	private static final String EMPTY = "";
+
 	@Autowired
 	private RegionService regionService;
 
@@ -40,7 +42,25 @@ class RegionServiceTest extends IntegrationTestSupport {
 		regionRepository.saveAll(FixtureFactory.createRegionFixtures(40));
 
 		// when
-		RegionSliceResponse regions = regionService.listAllRegions("", cursor);
+		RegionSliceResponse regions = regionService.listAllRegions(EMPTY, cursor);
+
+		// then
+		assertAll(
+			() -> assertThat(regions.isHasMore()).isEqualTo(hasNext),
+			() -> assertThat(regions.getRegions()).hasSize(size)
+		);
+	}
+
+	@DisplayName("cursor와 title 값에 해당하는 page의 동네 목록을 생성한다.")
+	@CsvSource(value = {"0,10,ten,false", "0,20,thirty,true"})
+	@ParameterizedTest
+	void listAllRegions(int cursor, int size, String title, boolean hasNext) {
+		// given
+		regionRepository.saveAll(FixtureFactory.createRegionFixtures(10, "size ten"));
+		regionRepository.saveAll(FixtureFactory.createRegionFixtures(30, "size thirty"));
+
+		// when
+		RegionSliceResponse regions = regionService.listAllRegions(title, cursor);
 
 		// then
 		assertAll(

--- a/src/test/java/com/codesquad/secondhand/api/service/region/RegionServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/region/RegionServiceTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
@@ -40,10 +38,9 @@ class RegionServiceTest extends IntegrationTestSupport {
 	void listAllRegions(int cursor, int size, boolean hasNext) {
 		// given
 		regionRepository.saveAll(FixtureFactory.createRegionFixtures(40));
-		Pageable pageable = PageRequest.of(cursor, size);
 
 		// when
-		RegionSliceResponse regions = regionService.listAllRegions(cursor);
+		RegionSliceResponse regions = regionService.listAllRegions("", cursor);
 
 		// then
 		assertAll(

--- a/src/test/java/com/codesquad/secondhand/domain/region/RegionRepositoryTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/region/RegionRepositoryTest.java
@@ -17,6 +17,8 @@ import com.codesquad.secondhand.domain.user_region.UserRegionRepository;
 
 class RegionRepositoryTest extends IntegrationTestSupport {
 
+	private static final String EMPTY = "";
+
 	@Autowired
 	private RegionRepository regionRepository;
 
@@ -38,7 +40,7 @@ class RegionRepositoryTest extends IntegrationTestSupport {
 		Pageable pageable = PageRequest.of(page, size);
 
 		// when
-		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, "");
+		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, EMPTY);
 
 		// then
 		assertThat(regions).hasSize(size);
@@ -53,7 +55,23 @@ class RegionRepositoryTest extends IntegrationTestSupport {
 		Pageable pageable = PageRequest.of(page, size);
 
 		// when
-		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, "");
+		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, EMPTY);
+
+		// then
+		assertThat(regions.hasNext()).isEqualTo(hasNext);
+	}
+
+	@DisplayName("검색 키워드를 포함하는 동네 목록을 응답합니다.")
+	@CsvSource(value = {"0,20,ten,false", "0,20,thirty,true"})
+	@ParameterizedTest
+	void hasNext(int page, int size, String title, boolean hasNext) {
+		// given
+		regionRepository.saveAll(FixtureFactory.createRegionFixtures(10, "size ten"));
+		regionRepository.saveAll(FixtureFactory.createRegionFixtures(30, "size thirty"));
+		Pageable pageable = PageRequest.of(page, size);
+
+		// when
+		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, title);
 
 		// then
 		assertThat(regions.hasNext()).isEqualTo(hasNext);

--- a/src/test/java/com/codesquad/secondhand/domain/region/RegionRepositoryTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/region/RegionRepositoryTest.java
@@ -13,14 +13,19 @@ import org.springframework.data.domain.Slice;
 
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
+import com.codesquad.secondhand.domain.user_region.UserRegionRepository;
 
 class RegionRepositoryTest extends IntegrationTestSupport {
 
 	@Autowired
 	private RegionRepository regionRepository;
 
+	@Autowired
+	private UserRegionRepository userRegionRepository;
+
 	@BeforeEach
 	private void init() {
+		userRegionRepository.deleteAllInBatch();
 		regionRepository.deleteAllInBatch();
 	}
 
@@ -33,7 +38,7 @@ class RegionRepositoryTest extends IntegrationTestSupport {
 		Pageable pageable = PageRequest.of(page, size);
 
 		// when
-		Slice<Region> regions = regionRepository.findSliceBy(pageable);
+		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, "");
 
 		// then
 		assertThat(regions).hasSize(size);
@@ -48,7 +53,7 @@ class RegionRepositoryTest extends IntegrationTestSupport {
 		Pageable pageable = PageRequest.of(page, size);
 
 		// when
-		Slice<Region> regions = regionRepository.findSliceBy(pageable);
+		Slice<Region> regions = regionRepository.findSliceByTitleContaining(pageable, "");
 
 		// then
 		assertThat(regions.hasNext()).isEqualTo(hasNext);


### PR DESCRIPTION
## Description

`/api/regions?title=역삼&cursor=0`

`title` 로 넘어온 키워드에 해당하는 동네 목록을 응답합니다.

### 응답 결과

- `title` 키워드가 없는 경우
<img width="435" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/b9a23bce-084a-4125-9ee4-20a41cd0b930">

- `title=수원` 을 추가한 경우
<img width="673" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/80ee7c7e-b317-4f50-9a08-449a106d37d4">


## Next Step

회원 가입과 로그인 어떡하지 고민 중...