### PR TITLE
사용자 정보 조회 시 NPE 에러 수정 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/controller/user/response/UserInformationResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user/response/UserInformationResponse.java
@@ -15,7 +15,7 @@ public class UserInformationResponse {
 
 	public static UserInformationResponse of(User user) {
 		return new UserInformationResponse(user.getId(), user.getNickname(),
-			user.getProfile().getImageUrl());
+			user.getProfileUrl());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -58,6 +58,10 @@ public class User extends BaseTimeEntity {
 	private String email;
 	private String password;
 
+	public String getProfileUrl() {
+		return profile == null ? null : profile.getImageUrl();
+	}
+
 	public List<UserRegion> listUserRegion() {
 		return myRegion.listAll();
 	}


### PR DESCRIPTION
## Description
사용자 정보 조회 시 `user`의 `profile`이 null인 경우 `user.profile.getImageUrl()`에서 NPE 발생하여 수정했습니다.
- `user`의 `profile`이 null인 경우 `NULL`을 반환하고 null이 아닌 경우 `user.profile.getImageUrl()`을 반환하도록 수정

this closes #46 