### PR TITLE
상품 등록/삭제/조회 API 구현 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
 
 	// Item
 	ITEM_FETCH_SUCCESS("상품 목록 조회를 성공하였습니다"),
+	ITEM_DETAIL_FETCH_SUCCESS("상품 조회를 성공하였습니다"),
 	ITEM_POST_SUCCESS("상품 등록을 성공하였습니다"),
 
 	// User

--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -15,6 +15,7 @@ public enum ResponseMessage {
 	ITEM_FETCH_SUCCESS("상품 목록 조회를 성공하였습니다"),
 	ITEM_DETAIL_FETCH_SUCCESS("상품 조회를 성공하였습니다"),
 	ITEM_POST_SUCCESS("상품 등록을 성공하였습니다"),
+	ITEM_DELETE_SUCCESS("상품 삭제를 성공하였습니다"),
 
 	// User
 	USER_REGION_FETCH_SUCCESS("나의 동네 조회를 성공하였습니다"),

--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
 
 	// Item
 	ITEM_FETCH_SUCCESS("상품 목록 조회를 성공하였습니다"),
+	ITEM_POST_SUCCESS("상품 등록을 성공하였습니다"),
 
 	// User
 	USER_REGION_FETCH_SUCCESS("나의 동네 조회를 성공하였습니다"),

--- a/src/main/java/com/codesquad/secondhand/api/controller/image/ImageController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/image/ImageController.java
@@ -1,0 +1,25 @@
+package com.codesquad.secondhand.api.controller.image;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.codesquad.secondhand.api.controller.image.request.ImageRequest;
+import com.codesquad.secondhand.api.service.image.ImageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+@RestController
+public class ImageController {
+
+	private final ImageService imageService;
+
+	@PostMapping
+	public void saveImage(@RequestPart MultipartFile image, @RequestPart ImageRequest request) {
+		imageService.createImage(image, request.getType());
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/image/request/ImageRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/image/request/ImageRequest.java
@@ -1,0 +1,12 @@
+package com.codesquad.secondhand.api.controller.image.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ImageRequest {
+
+	private String type;
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -48,9 +48,9 @@ public class ItemController {
 	}
 
 	@GetMapping("/{id}")
-	public ApiResponse<ItemDetailResponse> getItemDetail(@PathVariable Long id) {
+	public ApiResponse<ItemDetailResponse> getItemDetail(@PathVariable Long id, @SignIn SignInUser signInUser) {
 		return ApiResponse.of(HttpStatus.OK, ResponseMessage.ITEM_DETAIL_FETCH_SUCCESS.getMessage(),
-			itemService.getItemDetail(id));
+			itemService.getItemDetail(id, signInUser.getId()));
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -3,6 +3,7 @@ package com.codesquad.secondhand.api.controller.item;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import com.codesquad.secondhand.annotation.SignInUser;
 import com.codesquad.secondhand.api.ApiResponse;
 import com.codesquad.secondhand.api.ResponseMessage;
 import com.codesquad.secondhand.api.controller.item.request.ItemPostingRequest;
+import com.codesquad.secondhand.api.controller.item.response.ItemDetailResponse;
 import com.codesquad.secondhand.api.service.image.ImageService;
 import com.codesquad.secondhand.api.service.item.ItemService;
 import com.codesquad.secondhand.api.service.item.response.ItemSliceResponse;
@@ -43,6 +45,12 @@ public class ItemController {
 		itemService.postItem(request.toService(imageService.findImagesByIds(request.getImageIds())),
 			signInUser.getId());
 		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage());
+	}
+
+	@GetMapping("/{id}")
+	public ApiResponse<ItemDetailResponse> getItemDetail(@PathVariable Long id) {
+		return ApiResponse.of(HttpStatus.OK, ResponseMessage.ITEM_DETAIL_FETCH_SUCCESS.getMessage(),
+			itemService.getItemDetail(id));
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -3,12 +3,19 @@ package com.codesquad.secondhand.api.controller.item;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.codesquad.secondhand.annotation.SignIn;
+import com.codesquad.secondhand.annotation.SignInUser;
 import com.codesquad.secondhand.api.ApiResponse;
 import com.codesquad.secondhand.api.ResponseMessage;
+import com.codesquad.secondhand.api.controller.item.request.ItemPostingRequest;
+import com.codesquad.secondhand.api.service.image.ImageService;
 import com.codesquad.secondhand.api.service.item.ItemService;
 import com.codesquad.secondhand.api.service.item.response.ItemSliceResponse;
 
@@ -20,12 +27,22 @@ import lombok.RequiredArgsConstructor;
 public class ItemController {
 
 	private final ItemService itemService;
+	private final ImageService imageService;
 
+	@ResponseStatus(HttpStatus.OK)
 	@GetMapping
 	public ApiResponse<ItemSliceResponse> listFilteredItems(Pageable pageable,
 		@RequestParam Long category, @RequestParam Long region) {
 		return ApiResponse.of(HttpStatus.OK, ResponseMessage.ITEM_FETCH_SUCCESS.getMessage(),
 			itemService.listOfItems(category, region, pageable));
+	}
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping
+	public ApiResponse<Void> postItem(@RequestBody ItemPostingRequest request, @SignIn SignInUser signInUser) {
+		itemService.postItem(request.toService(imageService.findImagesByIds(request.getImageIds())),
+			signInUser.getId());
+		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -55,10 +55,11 @@ public class ItemController {
 			itemService.getItemDetail(id, signInUser.getId()));
 	}
 
+	@ResponseStatus(HttpStatus.OK)
 	@DeleteMapping("/{id}")
 	public ApiResponse<Void> deleteItem(@PathVariable Long id, @SignIn SignInUser signInUser) {
 		itemService.deleteItem(id, signInUser.getId());
-		return ApiResponse.noData(HttpStatus.NO_CONTENT, ResponseMessage.ITEM_DELETE_SUCCESS.getMessage());
+		return ApiResponse.noData(HttpStatus.OK, ResponseMessage.ITEM_DELETE_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -2,6 +2,7 @@ package com.codesquad.secondhand.api.controller.item;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,10 +48,17 @@ public class ItemController {
 		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage());
 	}
 
+	@ResponseStatus(HttpStatus.OK)
 	@GetMapping("/{id}")
 	public ApiResponse<ItemDetailResponse> getItemDetail(@PathVariable Long id, @SignIn SignInUser signInUser) {
 		return ApiResponse.of(HttpStatus.OK, ResponseMessage.ITEM_DETAIL_FETCH_SUCCESS.getMessage(),
 			itemService.getItemDetail(id, signInUser.getId()));
+	}
+
+	@DeleteMapping("/{id}")
+	public ApiResponse<Void> deleteItem(@PathVariable Long id, @SignIn SignInUser signInUser) {
+		itemService.deleteItem(id, signInUser.getId());
+		return ApiResponse.noData(HttpStatus.NO_CONTENT, ResponseMessage.ITEM_DELETE_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostingRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostingRequest.java
@@ -5,10 +5,12 @@ import java.util.List;
 import com.codesquad.secondhand.api.service.item.request.ItemPostingServiceRequest;
 import com.codesquad.secondhand.domain.image.Image;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class ItemPostingRequest {
 

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostingRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostingRequest.java
@@ -1,0 +1,26 @@
+package com.codesquad.secondhand.api.controller.item.request;
+
+import java.util.List;
+
+import com.codesquad.secondhand.api.service.item.request.ItemPostingServiceRequest;
+import com.codesquad.secondhand.domain.image.Image;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ItemPostingRequest {
+
+	private String title;
+	private Integer price;
+	private String content;
+	private List<Long> imageIds;
+	private Long categoryId;
+	private Long regionId;
+
+	public ItemPostingServiceRequest toService(List<Image> images) {
+		return new ItemPostingServiceRequest(title, price, content, images, categoryId, regionId);
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
@@ -1,0 +1,37 @@
+package com.codesquad.secondhand.api.controller.item.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item.Item;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ItemDetailResponse {
+
+	private Long id;
+	private String title;
+	private String status;
+	private String content;
+	private LocalDateTime updatedAt;
+	private Integer price;
+	private String category;
+	private ItemSellerResponse seller;
+	private int numChat;
+	private int numLike;
+	private Long numViews;
+	private List<Image> images;
+
+	public static ItemDetailResponse from(Item item) {
+		return new ItemDetailResponse(item.getId(), item.getTitle(), item.getStatus().getType(), item.getContent(),
+			item.getUpdatedAt(), item.getPrice(), item.getCategory().getTitle(), ItemSellerResponse.from(item.getUser()),
+			item.getNumChat(), item.getNumLike(), item.getViews(),item.listImage());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
@@ -7,12 +7,10 @@ import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.item.Item;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
 public class ItemDetailResponse {
 
 	private Long id;
@@ -24,14 +22,68 @@ public class ItemDetailResponse {
 	private String category;
 	private ItemSellerResponse seller;
 	private int numChat;
-	private int numLike;
+	private int numLikes;
 	private Long numViews;
+	private boolean isLiked;
 	private List<Image> images;
 
-	public static ItemDetailResponse from(Item item) {
+	public Long getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public LocalDateTime getUpdatedAt() {
+		return updatedAt;
+	}
+
+	public Integer getPrice() {
+		return price;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+
+	public ItemSellerResponse getSeller() {
+		return seller;
+	}
+
+	public int getNumChat() {
+		return numChat;
+	}
+
+	public int getNumLikes() {
+		return numLikes;
+	}
+
+	public Long getNumViews() {
+		return numViews;
+	}
+
+	public boolean getIsLiked() {
+		return isLiked;
+	}
+
+	public List<Image> getImages() {
+		return images;
+	}
+
+	public static ItemDetailResponse from(Item item, Long userId) {
 		return new ItemDetailResponse(item.getId(), item.getTitle(), item.getStatus().getType(), item.getContent(),
-			item.getUpdatedAt(), item.getPrice(), item.getCategory().getTitle(), ItemSellerResponse.from(item.getUser()),
-			item.getNumChat(), item.getNumLike(), item.getViews(),item.listImage());
+			item.getUpdatedAt(), item.getPrice(), item.getCategory().getTitle(),
+			ItemSellerResponse.from(item.getUser()), item.getNumChat(), item.getNumLikes(), item.getViews(),
+			item.isInWishlist(userId), item.listImage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemSellerResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemSellerResponse.java
@@ -1,0 +1,19 @@
+package com.codesquad.secondhand.api.controller.item.response;
+
+import com.codesquad.secondhand.domain.user.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ItemSellerResponse {
+
+	private Long id;
+	private String nickName;
+
+	public static ItemSellerResponse from(User user) {
+		return new ItemSellerResponse(user.getId(), user.getNickname());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
@@ -43,11 +43,11 @@ public class UserRegionController {
 		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.USER_REGION_CREATE_SUCCESS.getMessage());
 	}
 
-	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@ResponseStatus(HttpStatus.OK)
 	@DeleteMapping("/{id}")
 	public ApiResponse<Void> deleteUserRegion(@PathVariable Long id, @SignIn SignInUser signInUser) {
 		userRegionService.deleteUserRegion(signInUser.getId(), id);
-		return ApiResponse.noData(HttpStatus.NO_CONTENT, ResponseMessage.USER_REGION_DELETE_SUCCESS.getMessage());
+		return ApiResponse.noData(HttpStatus.OK, ResponseMessage.USER_REGION_DELETE_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/image/ImageService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/image/ImageService.java
@@ -3,6 +3,8 @@ package com.codesquad.secondhand.api.service.image;
 import static com.codesquad.secondhand.domain.image.ImageExtension.*;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -38,6 +40,11 @@ public class ImageService {
 	@Transactional
 	public Image createImage(MultipartFile file, String directory) {
 		return imageRepository.save(new Image(null, upload(file, directory)));
+	}
+
+	@Transactional(readOnly = true)
+	public List<Image> findImagesByIds(List<Long> imageIds) {
+		return Collections.unmodifiableList(imageRepository.findAllById(imageIds));
 	}
 
 	private String upload(MultipartFile multipartFile, String directory) {

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.codesquad.secondhand.api.controller.item.response.ItemDetailResponse;
 import com.codesquad.secondhand.api.service.item.request.ItemPostingServiceRequest;
 import com.codesquad.secondhand.api.service.item.response.ItemResponse;
 import com.codesquad.secondhand.api.service.item.response.ItemSliceResponse;
@@ -23,6 +24,7 @@ import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.user.UserRepository;
 import com.codesquad.secondhand.exception.category.NoSuchCategoryException;
+import com.codesquad.secondhand.exception.item.NoSuchItemException;
 import com.codesquad.secondhand.exception.region.NoSuchRegionException;
 import com.codesquad.secondhand.exception.status.NoSuchStatusException;
 import com.codesquad.secondhand.exception.user.NoSuchUserException;
@@ -74,6 +76,13 @@ public class ItemService {
 
 		item.addItemImages(request.getImages());
 		itemRepository.save(item);
+	}
+
+	// todo : isWishlisted & incrementView
+	@Transactional(readOnly = true)
+	public ItemDetailResponse getItemDetail(Long itemId) {
+		Item item = itemRepository.findDetailById(itemId).orElseThrow(NoSuchItemException::new);
+		return ItemDetailResponse.from(item);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -1,15 +1,31 @@
 package com.codesquad.secondhand.api.service.item;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.codesquad.secondhand.api.service.item.request.ItemPostingServiceRequest;
 import com.codesquad.secondhand.api.service.item.response.ItemResponse;
 import com.codesquad.secondhand.api.service.item.response.ItemSliceResponse;
+import com.codesquad.secondhand.domain.category.Category;
+import com.codesquad.secondhand.domain.category.CategoryRepository;
+import com.codesquad.secondhand.domain.item.Item;
 import com.codesquad.secondhand.domain.item.ItemRepository;
 import com.codesquad.secondhand.domain.item.QueryItemRepository;
+import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.region.RegionRepository;
+import com.codesquad.secondhand.domain.status.Status;
+import com.codesquad.secondhand.domain.status.StatusRepository;
+import com.codesquad.secondhand.domain.user.User;
+import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.exception.category.NoSuchCategoryException;
+import com.codesquad.secondhand.exception.region.NoSuchRegionException;
+import com.codesquad.secondhand.exception.status.NoSuchStatusException;
+import com.codesquad.secondhand.exception.user.NoSuchUserException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,14 +33,46 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class ItemService {
 
+	private static final Long FOR_SALE_ID = 1L;
+	private static final Long SOLD_OUT_ID = 2L;
+	private static final Long RESERVATION_ID = 3L;
+
 	private final ItemRepository itemRepository;
+	private final UserRepository userRepository;
+	private final CategoryRepository categoryRepository;
+	private final RegionRepository regionRepository;
+	private final StatusRepository statusRepository;
 	private final QueryItemRepository queryItemRepository;
 
+	@Transactional(readOnly = true)
 	public ItemSliceResponse listOfItems(Long categoryId, Long regionId, Pageable pageable) {
 		Slice<ItemResponse> responses = queryItemRepository.filteredListByCategoryAndRegion(categoryId, regionId, pageable);
 		List<ItemResponse> itemList = responses.getContent();
 
 		return new ItemSliceResponse(responses.hasNext(), itemList);
+	}
+
+	@Transactional
+	public void postItem(ItemPostingServiceRequest request, Long userId) {
+		User seller = userRepository.findById(userId).orElseThrow(NoSuchUserException::new);
+		Region region = regionRepository.findById(request.getRegionId()).orElseThrow(NoSuchRegionException::new);
+		seller.validateHasRegion(region);
+		Category category = categoryRepository.findById(request.getCategoryId())
+			.orElseThrow(NoSuchCategoryException::new);
+		Status status = statusRepository.findById(FOR_SALE_ID).orElseThrow(NoSuchStatusException::new);
+
+		Item item = new Item(
+			seller,
+			category,
+			region,
+			status,
+			LocalDateTime.now(),
+			request.getTitle(),
+			request.getContent(),
+			request.getPrice()
+		);
+
+		item.addItemImages(request.getImages());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -80,9 +80,9 @@ public class ItemService {
 
 	// todo : isWishlisted & incrementView
 	@Transactional(readOnly = true)
-	public ItemDetailResponse getItemDetail(Long itemId) {
+	public ItemDetailResponse getItemDetail(Long itemId, Long userId) {
 		Item item = itemRepository.findDetailById(itemId).orElseThrow(NoSuchItemException::new);
-		return ItemDetailResponse.from(item);
+		return ItemDetailResponse.from(item, userId);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -78,7 +78,7 @@ public class ItemService {
 		itemRepository.save(item);
 	}
 
-	// todo : isWishlisted & incrementView
+	// todo : incrementView
 	@Transactional(readOnly = true)
 	public ItemDetailResponse getItemDetail(Long itemId, Long userId) {
 		Item item = itemRepository.findDetailById(itemId).orElseThrow(NoSuchItemException::new);

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -73,6 +73,7 @@ public class ItemService {
 		);
 
 		item.addItemImages(request.getImages());
+		itemRepository.save(item);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -85,4 +85,12 @@ public class ItemService {
 		return ItemDetailResponse.from(item, userId);
 	}
 
+	// todo : 이미지 삭제 여부
+	@Transactional
+	public void deleteItem(Long itemId, Long userId) {
+		userRepository.findById(userId).orElseThrow(NoSuchUserException::new);
+		Item item = itemRepository.findDetailById(itemId).orElseThrow(NoSuchItemException::new);
+		item.delete(userId);
+	}
+
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/item/request/ItemPostingServiceRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/request/ItemPostingServiceRequest.java
@@ -1,0 +1,21 @@
+package com.codesquad.secondhand.api.service.item.request;
+
+import java.util.List;
+
+import com.codesquad.secondhand.domain.image.Image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ItemPostingServiceRequest {
+
+	private String title;
+	private Integer price;
+	private String content;
+	private List<Image> images;
+	private Long categoryId;
+	private Long regionId;
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
@@ -17,12 +17,12 @@ public class ItemResponse {
 	private LocalDateTime updatedAt;
 	private Integer price;
 	private Long numChat;
-	private Long numLike;
+	private Long numLikes;
 
 	@QueryProjection
 	public ItemResponse(Long id, String title, String region, String status, String imageUrl,
 		LocalDateTime createdAt,
-		LocalDateTime updatedAt, Integer price, Long numChat, Long numLike) {
+		LocalDateTime updatedAt, Integer price, Long numChat, Long numLikes) {
 		this.id = id;
 		this.title = title;
 		this.region = region;
@@ -32,7 +32,7 @@ public class ItemResponse {
 		this.updatedAt = updatedAt;
 		this.price = price;
 		this.numChat = numChat;
-		this.numLike = numLike;
+		this.numLikes = numLikes;
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item/DetailShot.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/DetailShot.java
@@ -2,6 +2,7 @@ package com.codesquad.secondhand.domain.item;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
@@ -20,8 +21,10 @@ public class DetailShot {
 	@OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<ItemImage> itemImages = new ArrayList<>();
 
-	public List<ItemImage> listAll() {
-		return List.copyOf(itemImages);
+	public List<Image> listAllImages() {
+		return itemImages.stream()
+			.map(ItemImage::getImage)
+			.collect(Collectors.toUnmodifiableList());
 	}
 
 	public void addImage(ItemImage itemImage) {

--- a/src/main/java/com/codesquad/secondhand/domain/item/DetailShot.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/DetailShot.java
@@ -1,0 +1,41 @@
+package com.codesquad.secondhand.domain.item;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item_image.ItemImage;
+import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Embeddable
+public class DetailShot {
+
+	@OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+	private final List<ItemImage> itemImages = new ArrayList<>();
+
+	public List<ItemImage> listAll() {
+		return List.copyOf(itemImages);
+	}
+
+	public void addImage(ItemImage itemImage) {
+		itemImages.add(itemImage);
+	}
+
+	public void removeImage(Image image) {
+		itemImages.remove(validateItemImage(image));
+	}
+
+	private ItemImage validateItemImage(Image image) {
+		return itemImages.stream()
+			.filter(i -> i.findImageId().equals(image.getId()))
+			.findFirst()
+			.orElseThrow(NoSuchItemImageException::new);
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -19,18 +20,19 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import com.codesquad.secondhand.domain.category.Category;
 import com.codesquad.secondhand.domain.chat.Chat;
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item_image.ItemImage;
 import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.wishlist.WishList;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Entity
 @Table(name = "item")
@@ -56,8 +58,8 @@ public class Item extends BaseTimeEntity {
 	@JoinColumn(name = "status_id")
 	private Status status;
 
-	@OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
-	private List<ItemImage> itemImages = new ArrayList<>();
+	@Embedded
+	private DetailShot detailShot;
 
 	@OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
 	private List<WishList> wishLists = new ArrayList<>();
@@ -71,6 +73,37 @@ public class Item extends BaseTimeEntity {
 	private String title;
 	private String content;
 	private Integer price;
+	private Long views;
 	private boolean isDeleted;
+
+	// todo : 정적 팩토리 메서드? Build 패턴?
+	public Item(User user, Category category, Region region, Status status,
+		LocalDateTime updatedAt, String title, String content, Integer price) {
+		this.user = user;
+		this.category = category;
+		this.region = region;
+		this.status = status;
+		this.detailShot = new DetailShot();
+		this.updatedAt = updatedAt;
+		this.title = title;
+		this.content = content;
+		this.price = price;
+		this.views = 0L;
+		this.isDeleted = false;
+	}
+
+	public List<ItemImage> listItemImage() {
+		return detailShot.listAll();
+	}
+
+	public void addItemImages(List<Image> images) {
+		for(Image image : images) {
+			detailShot.addImage(new ItemImage(null, this, image));
+		}
+	}
+
+	public void removeItemImage(Image image) {
+		detailShot.removeImage(image);
+	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -100,8 +100,13 @@ public class Item extends BaseTimeEntity {
 		return this.getChats().size();
 	}
 
-	public int getNumLike() {
+	public int getNumLikes() {
 		return this.getWishLists().size();
+	}
+
+	public boolean isInWishlist(Long userId) {
+		return wishLists.stream()
+			.anyMatch(w -> w.getUser().isSameUserAs(userId));
 	}
 
 	public void addItemImages(List<Image> images) {

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -119,4 +119,9 @@ public class Item extends BaseTimeEntity {
 		detailShot.removeImage(image);
 	}
 
+	public void delete(Long targetUserId) {
+		this.user.validateSameUser(targetUserId);
+		this.isDeleted = true;
+	}
+
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -92,8 +92,16 @@ public class Item extends BaseTimeEntity {
 		this.isDeleted = false;
 	}
 
-	public List<ItemImage> listItemImage() {
-		return detailShot.listAll();
+	public List<Image> listImage() {
+		return detailShot.listAllImages();
+	}
+
+	public int getNumChat() {
+		return this.getChats().size();
+	}
+
+	public int getNumLike() {
+		return this.getWishLists().size();
 	}
 
 	public void addItemImages(List<Image> images) {

--- a/src/main/java/com/codesquad/secondhand/domain/item/ItemRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/ItemRepository.java
@@ -8,13 +8,14 @@ import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-	@Query("select i from Item i "
-		+ "inner join fetch i.user "
-		+ "inner join fetch i.category "
-		+ "inner join fetch i.region "
-		+ "inner join fetch i.status "
-		+ "left join fetch i.detailShot.itemImages ii "
-		+ "left join fetch ii.image "
-		+ "where i.id = :id and i.isDeleted = false")
+	@Query("SELECT i FROM Item i "
+		+ "INNER JOIN FETCH i.user "
+		+ "INNER JOIN FETCH i.category "
+		+ "INNER JOIN FETCH i.region "
+		+ "INNER JOIN FETCH i.status "
+		+ "LEFT JOIN FETCH i.detailShot.itemImages ii "
+		+ "LEFT JOIN FETCH ii.image "
+		+ "WHERE i.id = :id AND i.isDeleted = FALSE")
 	Optional<Item> findDetailById(@Param("id") Long itemId);
+
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item/ItemRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/ItemRepository.java
@@ -1,7 +1,20 @@
 package com.codesquad.secondhand.domain.item;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
+	@Query("select i from Item i "
+		+ "inner join fetch i.user "
+		+ "inner join fetch i.category "
+		+ "inner join fetch i.region "
+		+ "inner join fetch i.status "
+		+ "left join fetch i.detailShot.itemImages ii "
+		+ "left join fetch ii.image "
+		+ "where i.id = :id and i.isDeleted = false")
+	Optional<Item> findDetailById(@Param("id") Long itemId);
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item/QueryItemRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/QueryItemRepository.java
@@ -3,7 +3,7 @@ package com.codesquad.secondhand.domain.item;
 import static com.codesquad.secondhand.domain.chat.QChat.*;
 import static com.codesquad.secondhand.domain.image.QImage.*;
 import static com.codesquad.secondhand.domain.item.QItem.*;
-import static com.codesquad.secondhand.domain.item.QItemImage.*;
+import static com.codesquad.secondhand.domain.item_image.QItemImage.*;
 import static com.codesquad.secondhand.domain.region.QRegion.*;
 import static com.codesquad.secondhand.domain.wishlist.QWishList.*;
 
@@ -49,7 +49,7 @@ public class QueryItemRepository {
 				categoryIdEq(categoryId)
 			)
 			.leftJoin(item.region, region)
-			.leftJoin(item.itemImages, itemImage)
+			.leftJoin(item.detailShot.itemImages, itemImage)
 			.leftJoin(itemImage.image, image)
 			.leftJoin(item.chats, chat)
 			.leftJoin(item.wishLists, wishList)

--- a/src/main/java/com/codesquad/secondhand/domain/item_image/ItemImage.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item_image/ItemImage.java
@@ -1,4 +1,4 @@
-package com.codesquad.secondhand.domain.item;
+package com.codesquad.secondhand.domain.item_image;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -11,10 +11,16 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item.Item;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Entity
 @Table(name = "item_image")
@@ -32,4 +38,7 @@ public class ItemImage extends BaseTimeEntity {
 	@JoinColumn(name = "image_id")
 	private Image image;
 
+	public Long findImageId() {
+		return this.image.getId();
+	}
 }

--- a/src/main/java/com/codesquad/secondhand/domain/item_image/ItemImage.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item_image/ItemImage.java
@@ -12,7 +12,6 @@ import javax.persistence.Table;
 
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.item.Item;
-import com.codesquad.secondhand.util.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "item_image")
-public class ItemImage extends BaseTimeEntity {
+public class ItemImage {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codesquad/secondhand/domain/status/Status.java
+++ b/src/main/java/com/codesquad/secondhand/domain/status/Status.java
@@ -1,4 +1,4 @@
-package com.codesquad.secondhand.domain.item;
+package com.codesquad.secondhand.domain.status;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -6,8 +6,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Entity
 @Table(name = "status")

--- a/src/main/java/com/codesquad/secondhand/domain/status/StatusRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/status/StatusRepository.java
@@ -1,0 +1,6 @@
+package com.codesquad.secondhand.domain.status;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatusRepository extends JpaRepository<Status, Long> {
+}

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -22,6 +22,7 @@ import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.user_region.UserRegion;
 import com.codesquad.secondhand.domain.wishlist.WishList;
+import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
@@ -81,8 +82,14 @@ public class User extends BaseTimeEntity {
 		this.profile = newProfile;
 	}
 
-	public boolean isSameUserAs(Long userId){
-		return Objects.equals(this.id, userId);
+	public void validateSameUser(Long targetUserId) {
+		if(!isSameUserAs(targetUserId)) {
+			throw new PermissionDeniedException();
+		}
+	}
+
+	public boolean isSameUserAs(Long targetUserId){
+		return Objects.equals(this.id, targetUserId);
 	}
 
 	// todo : 위치 확인

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -21,6 +21,7 @@ import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.user_region.UserRegion;
 import com.codesquad.secondhand.domain.wishlist.WishList;
+import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -77,6 +78,16 @@ public class User extends BaseTimeEntity {
 	public void updateInformation(String newNickname, Image newProfile) {
 		this.nickname = newNickname;
 		this.profile = newProfile;
+	}
+
+	// todo : 위치 확인
+	public void validateHasRegion(Region region) {
+		boolean hasRegion = myRegion.listAll()
+			.stream()
+			.anyMatch(userRegion -> userRegion.getRegion().equals(region));
+		if(!hasRegion) {
+			throw new NoSuchUserRegionException();
+		}
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -2,6 +2,7 @@ package com.codesquad.secondhand.domain.user;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
@@ -78,6 +79,10 @@ public class User extends BaseTimeEntity {
 	public void updateInformation(String newNickname, Image newProfile) {
 		this.nickname = newNickname;
 		this.profile = newProfile;
+	}
+
+	public boolean isSameUserAs(Long userId){
+		return Objects.equals(this.id, userId);
 	}
 
 	// todo : 위치 확인

--- a/src/main/java/com/codesquad/secondhand/exception/auth/AuthExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/AuthExceptionHandler.java
@@ -22,4 +22,10 @@ public class AuthExceptionHandler {
 		return ApiResponse.noData(HttpStatus.FORBIDDEN, exception.getMessage());
 	}
 
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler(PermissionDeniedException.class)
+	public ApiResponse<Void> handlePermissionDeniedException(PermissionDeniedException exception) {
+		return ApiResponse.noData(HttpStatus.UNAUTHORIZED, exception.getMessage());
+	}
+
 }

--- a/src/main/java/com/codesquad/secondhand/exception/auth/PermissionDeniedException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/PermissionDeniedException.java
@@ -1,0 +1,10 @@
+package com.codesquad.secondhand.exception.auth;
+
+public class PermissionDeniedException extends RuntimeException {
+
+	private static final String MESSAGE = "허가되지 않은 접근입니다";
+
+	public PermissionDeniedException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/category/NoSuchCategoryException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/category/NoSuchCategoryException.java
@@ -1,0 +1,11 @@
+package com.codesquad.secondhand.exception.category;
+
+public class NoSuchCategoryException extends RuntimeException {
+
+	private static final String MESSAGE = "존재하지 않는 카테고리입니다";
+
+	public NoSuchCategoryException() {
+		super(MESSAGE);
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/exception/image/NoSuchImageException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/image/NoSuchImageException.java
@@ -1,0 +1,10 @@
+package com.codesquad.secondhand.exception.image;
+
+public class NoSuchImageException extends RuntimeException {
+
+	private final static String MESSAGE = "존재하지 않는 이미지입니다";
+
+	public NoSuchImageException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/item/ItemExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item/ItemExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.codesquad.secondhand.exception.item;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.codesquad.secondhand.api.ApiResponse;
+
+@RestControllerAdvice
+public class ItemExceptionHandler {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(NoSuchItemException.class)
+	public ApiResponse<Void> handleNoSuchItemException(NoSuchItemException exception) {
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/item/NoSuchItemException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item/NoSuchItemException.java
@@ -1,0 +1,10 @@
+package com.codesquad.secondhand.exception.item;
+
+public class NoSuchItemException extends RuntimeException {
+
+	private static final String MESSAGE = "존재하지 않는 상품입니다";
+
+	public NoSuchItemException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/item_image/ItemImageExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item_image/ItemImageExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.codesquad.secondhand.exception.item_image;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.codesquad.secondhand.api.ApiResponse;
+
+@RestControllerAdvice
+public class ItemImageExceptionHandler {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(NoSuchItemImageException.class)
+	public ApiResponse<Void> handleNoSuchItemImageException(NoSuchItemImageException exception) {
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/item_image/NoSuchItemImageException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item_image/NoSuchItemImageException.java
@@ -1,0 +1,9 @@
+package com.codesquad.secondhand.exception.item_image;
+
+public class NoSuchItemImageException extends RuntimeException {
+	private final static String MESSAGE = "존재하지 않는 상품 이미지입니다";
+
+	public NoSuchItemImageException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/exception/status/NoSuchStatusException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/status/NoSuchStatusException.java
@@ -1,0 +1,10 @@
+package com.codesquad.secondhand.exception.status;
+
+public class NoSuchStatusException extends RuntimeException {
+
+	private static final String MESSAGE = "존재하지 않는 상품 상태입니다";
+
+	public NoSuchStatusException() {
+		super(MESSAGE);
+	}
+}

--- a/src/test/java/com/codesquad/secondhand/ControllerTestSupport.java
+++ b/src/test/java/com/codesquad/secondhand/ControllerTestSupport.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.codesquad.secondhand.api.controller.auth.AuthController;
 import com.codesquad.secondhand.api.controller.category.CategoryController;
+import com.codesquad.secondhand.api.controller.item.ItemController;
 import com.codesquad.secondhand.api.controller.region.RegionController;
 import com.codesquad.secondhand.api.controller.user.UserController;
 import com.codesquad.secondhand.api.controller.user_region.UserRegionController;
@@ -17,6 +18,7 @@ import com.codesquad.secondhand.api.service.auth.AuthService;
 import com.codesquad.secondhand.api.service.auth.jwt.JwtService;
 import com.codesquad.secondhand.api.service.category.CategoryService;
 import com.codesquad.secondhand.api.service.image.ImageService;
+import com.codesquad.secondhand.api.service.item.ItemService;
 import com.codesquad.secondhand.api.service.region.RegionService;
 import com.codesquad.secondhand.api.service.user.UserService;
 import com.codesquad.secondhand.api.service.user_region.UserRegionService;
@@ -29,6 +31,8 @@ import io.jsonwebtoken.Jwts;
 	RegionController.class,
 	UserController.class,
 	UserRegionController.class,
+	CategoryController.class,
+	ItemController.class,
 	CategoryController.class,
 	AuthController.class
 })
@@ -50,13 +54,16 @@ public abstract class ControllerTestSupport {
 	protected CategoryService categoryService;
 
 	@MockBean
+	protected ItemService itemService;
+
+	@MockBean
+	protected ImageService imageService;
+
+	@MockBean
 	protected JwtService jwtService;
 
 	@MockBean
 	protected UserService userService;
-
-	@MockBean
-	protected ImageService imageService;
 
 	@MockBean
 	protected AuthService authService;

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -5,8 +5,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.codesquad.secondhand.domain.category.Category;
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item.Item;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.user.MyRegion;
 import com.codesquad.secondhand.domain.user.User;
 
@@ -42,6 +45,23 @@ public abstract class FixtureFactory {
 			"password123!");
 		regions.forEach(user::addUserRegion);
 		return user;
+	}
+
+	public static List<Image> createImageListFixtures(int size) {
+		return IntStream.rangeClosed(1, size)
+			.mapToObj(i -> new Image(null, "imageUrl" + i + ".jpg"))
+			.collect(Collectors.toList());
+	}
+
+	public static Item createItemFixtures(User user, Category category, Region region, Status status) {
+		return new Item(user, category, region, status, LocalDateTime.now(), "title", "content", null);
+	}
+
+	public static List<Status> createStatusFixtures() {
+		Status forSale = new Status(1L, "판매중");
+		Status soleOut = new Status(2L, "판매완료");
+		Status reservation = new Status(3L, "예약중");
+		return List.of(forSale, soleOut, reservation);
 	}
 
 }

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -16,6 +16,8 @@ import com.codesquad.secondhand.domain.user.User;
 
 public abstract class FixtureFactory {
 
+	public static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
+
 	public static List<Region> createRegionFixtures(int size) {
 		return IntStream.rangeClosed(1, size)
 			.mapToObj(i -> new Region(null, "test region" + i))
@@ -55,7 +57,7 @@ public abstract class FixtureFactory {
 	}
 
 	public static Item createItemFixtures(User user, Category category, Region region, Status status) {
-		return new Item(user, category, region, status, LocalDateTime.now(), "title", "content", null);
+		return new Item(user, category, region, status, LOCAL_DATE_TIME, "title", "content", null);
 	}
 
 	public static List<Status> createStatusFixtures() {

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -1,5 +1,6 @@
 package com.codesquad.secondhand;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -47,7 +48,7 @@ public abstract class FixtureFactory {
 		return user;
 	}
 
-	public static List<Image> createImageListFixtures(int size) {
+	public static List<Image> createImageFixtures(int size) {
 		return IntStream.rangeClosed(1, size)
 			.mapToObj(i -> new Image(null, "imageUrl" + i + ".jpg"))
 			.collect(Collectors.toList());

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -14,11 +14,8 @@ import org.mockito.Mockito;
 import org.springframework.http.MediaType;
 
 import com.codesquad.secondhand.ControllerTestSupport;
-import com.codesquad.secondhand.annotation.SignInUser;
 import com.codesquad.secondhand.api.controller.item.request.ItemPostingRequest;
 import com.codesquad.secondhand.domain.image.Image;
-import com.codesquad.secondhand.domain.provider.Provider;
-import com.codesquad.secondhand.domain.user.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Claims;
@@ -29,8 +26,6 @@ public class ItemControllerTest extends ControllerTestSupport {
 	@BeforeEach
 	void mockingJwtService() {
 		given(jwtService.parse(Mockito.any())).willReturn(createMockClaims());
-		Provider provider = new Provider(Provider.ofLocal().getId(), Provider.ofLocal().getType());
-		User user = new User(1L, null, null, provider, null, "name", "email@email.com", "password1!");
 	}
 
 	private Claims createMockClaims() {
@@ -43,7 +38,6 @@ public class ItemControllerTest extends ControllerTestSupport {
 	@Test
 	void postItem() throws Exception {
 		// given
-		SignInUser signInUser = new SignInUser(1L);
 		ItemPostingRequest request = new ItemPostingRequest("title", null, "content", List.of(1L, 2L), 1L, 1L);
 
 		// when

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -1,0 +1,63 @@
+package com.codesquad.secondhand.api.controller.item;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+
+import com.codesquad.secondhand.ControllerTestSupport;
+import com.codesquad.secondhand.annotation.SignInUser;
+import com.codesquad.secondhand.api.controller.item.request.ItemPostingRequest;
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.provider.Provider;
+import com.codesquad.secondhand.domain.user.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+public class ItemControllerTest extends ControllerTestSupport {
+
+	@BeforeEach
+	void mockingJwtService() {
+		given(jwtService.parse(Mockito.any())).willReturn(createMockClaims());
+		Provider provider = new Provider(Provider.ofLocal().getId(), Provider.ofLocal().getType());
+		User user = new User(1L, null, null, provider, null, "name", "email@email.com", "password1!");
+	}
+
+	private Claims createMockClaims() {
+		Claims claims = Jwts.claims();
+		claims.put("id", 1L);
+		return claims;
+	}
+
+	@DisplayName("새로운 상품을 등록하고 201을 응답한다.")
+	@Test
+	void postItem() throws Exception {
+		// given
+		SignInUser signInUser = new SignInUser(1L);
+		ItemPostingRequest request = new ItemPostingRequest("title", null, "content", List.of(1L, 2L), 1L, 1L);
+
+		// when
+		ObjectMapper objectMapper = new ObjectMapper();
+		when(imageService.findImagesByIds(request.getImageIds())).thenReturn(
+			List.of(new Image(1L, "1.jpg"), new Image(2L, "2.jpg")));
+
+		// then
+		mockMvc.perform(post("/api/items")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.header("Authorization", "Bearer test-access-token"))
+			.andDo(print())
+			.andExpect(status().isCreated());
+	}
+
+}

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,8 @@ import org.springframework.http.MediaType;
 
 import com.codesquad.secondhand.ControllerTestSupport;
 import com.codesquad.secondhand.api.controller.item.request.ItemPostingRequest;
+import com.codesquad.secondhand.api.controller.item.response.ItemDetailResponse;
+import com.codesquad.secondhand.api.controller.item.response.ItemSellerResponse;
 import com.codesquad.secondhand.domain.image.Image;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -22,6 +25,9 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 
 public class ItemControllerTest extends ControllerTestSupport {
+
+	private static final String HEADER_NAME = "Authorization";
+	private static final String HEADER_VALUE = "Bearer test-access-token";
 
 	@BeforeEach
 	void mockingJwtService() {
@@ -49,9 +55,40 @@ public class ItemControllerTest extends ControllerTestSupport {
 		mockMvc.perform(post("/api/items")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
-				.header("Authorization", "Bearer test-access-token"))
+				.header(HEADER_NAME, HEADER_VALUE))
 			.andDo(print())
-			.andExpect(status().isCreated());
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.message").value("상품 등록을 성공하였습니다"));
 	}
 
+	@DisplayName("상품을 상세 조회하고 200을 응답한다.")
+	@Test
+	void getItemDetail() throws Exception {
+		// given
+		Long itemId = 1L;
+		ItemSellerResponse sellerResponse = new ItemSellerResponse(1L, "nickname");
+		ItemDetailResponse itemResponse = new ItemDetailResponse(1L, "title", "판매중", "content", LocalDateTime.now(),
+			null, "가전", sellerResponse, 0, 0, 0L, false, null);
+
+		when(itemService.getItemDetail(anyLong(), anyLong())).thenReturn(itemResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/items/" + itemId)
+				.header(HEADER_NAME, HEADER_VALUE))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("상품 조회를 성공하였습니다"))
+			.andExpect(jsonPath("$.data.id").value(1L))
+			.andExpect(jsonPath("$.data.title").value("title"))
+			.andExpect(jsonPath("$.data.content").value("content"))
+			.andExpect(jsonPath("$.data.price").doesNotExist())
+			.andExpect(jsonPath("$.data.category").value("가전"))
+			.andExpect(jsonPath("$.data.seller.id").value(1L))
+			.andExpect(jsonPath("$.data.seller.nickName").value("nickname"))
+			.andExpect(jsonPath("$.data.numChat").value(0))
+			.andExpect(jsonPath("$.data.numLikes").value(0))
+			.andExpect(jsonPath("$.data.numViews").value(0L))
+			.andExpect(jsonPath("$.data.isLiked").value(false))
+			.andExpect(jsonPath("$.data.images").doesNotExist());
+	}
 }

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -91,4 +91,5 @@ public class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.data.isLiked").value(false))
 			.andExpect(jsonPath("$.data.images").doesNotExist());
 	}
+
 }

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -8,10 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.MediaType;
 
 import com.codesquad.secondhand.ControllerTestSupport;
@@ -21,29 +19,16 @@ import com.codesquad.secondhand.api.controller.item.response.ItemSellerResponse;
 import com.codesquad.secondhand.domain.image.Image;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-
 public class ItemControllerTest extends ControllerTestSupport {
 
 	private static final String HEADER_NAME = "Authorization";
 	private static final String HEADER_VALUE = "Bearer test-access-token";
 
-	@BeforeEach
-	void mockingJwtService() {
-		given(jwtService.parse(Mockito.any())).willReturn(createMockClaims());
-	}
-
-	private Claims createMockClaims() {
-		Claims claims = Jwts.claims();
-		claims.put("id", 1L);
-		return claims;
-	}
-
 	@DisplayName("새로운 상품을 등록하고 201을 응답한다.")
 	@Test
 	void postItem() throws Exception {
 		// given
+		mockingJwtService();
 		ItemPostingRequest request = new ItemPostingRequest("title", null, "content", List.of(1L, 2L), 1L, 1L);
 
 		// when
@@ -65,6 +50,7 @@ public class ItemControllerTest extends ControllerTestSupport {
 	@Test
 	void getItemDetail() throws Exception {
 		// given
+		mockingJwtService();
 		Long itemId = 1L;
 		ItemSellerResponse sellerResponse = new ItemSellerResponse(1L, "nickname");
 		ItemDetailResponse itemResponse = new ItemDetailResponse(1L, "title", "판매중", "content", LocalDateTime.now(),

--- a/src/test/java/com/codesquad/secondhand/api/controller/user_region/UserRegionControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/user_region/UserRegionControllerTest.java
@@ -49,7 +49,7 @@ class UserRegionControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.message").value(ResponseMessage.USER_REGION_CREATE_SUCCESS.getMessage()));
 	}
 
-	@DisplayName("사용자 동네 삭제에 성공하면 204를 응답한다.")
+	@DisplayName("사용자 동네 삭제에 성공하면 200을 응답한다.")
 	@Test
 	void deleteUserRegion() throws Exception {
 		// // given
@@ -58,7 +58,7 @@ class UserRegionControllerTest extends ControllerTestSupport {
 		// when // then
 		mockMvc.perform(delete("/api/users/regions/1"))
 			.andDo(print())
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 	}
 
 }

--- a/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
@@ -67,10 +67,10 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		regions = FixtureFactory.createRegionFixtures(3);
 		regionRepository.saveAll(regions);
 
-		loginUser = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0), regions.get(1)));
+		loginUser = FixtureFactory.createUserFixture(List.of(regions.get(0), regions.get(1)));
 		userRepository.save(loginUser);
 
-		categories = FixtureFactory.createCategoryFixture(3);
+		categories = FixtureFactory.createCategoryFixtures(3);
 		categoryRepository.saveAll(categories);
 
 		images = FixtureFactory.createImageFixtures(3);
@@ -164,7 +164,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 	@Test
 	void getItemDetail() {
 		// given
-		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		User seller = FixtureFactory.createUserFixture(List.of(regions.get(0)));
 		userRepository.save(seller);
 		Item item = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
 		item.addItemImages(images);
@@ -221,7 +221,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 	@Test
 	void deleteItemAndThrowPermissionDeniedException() {
 		// given
-		User otheruser = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		User otheruser = FixtureFactory.createUserFixture(List.of(regions.get(0)));
 		userRepository.save(otheruser);
 		Item item = FixtureFactory.createItemFixtures(otheruser, categories.get(0), regions.get(0), statusList.get(0));
 		itemRepository.save(item);

--- a/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
@@ -1,0 +1,155 @@
+package com.codesquad.secondhand.api.service.item;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.codesquad.secondhand.FixtureFactory;
+import com.codesquad.secondhand.IntegrationTestSupport;
+import com.codesquad.secondhand.api.service.item.request.ItemPostingServiceRequest;
+import com.codesquad.secondhand.domain.category.Category;
+import com.codesquad.secondhand.domain.category.CategoryRepository;
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.image.ImageRepository;
+import com.codesquad.secondhand.domain.item.Item;
+import com.codesquad.secondhand.domain.item.ItemRepository;
+import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.region.RegionRepository;
+import com.codesquad.secondhand.domain.status.Status;
+import com.codesquad.secondhand.domain.status.StatusRepository;
+import com.codesquad.secondhand.domain.user.User;
+import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.exception.category.NoSuchCategoryException;
+import com.codesquad.secondhand.exception.item.NoSuchItemException;
+import com.codesquad.secondhand.exception.region.NoSuchRegionException;
+import com.codesquad.secondhand.exception.user.NoSuchUserException;
+import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
+
+public class ItemServiceTest extends IntegrationTestSupport {
+
+	private static List<Region> regions;
+	private static List<Category> categories;
+	private static User user;
+	private static List<Image> images;
+	private static List<Status> statusList;
+	@Autowired
+	private ItemService itemService;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private RegionRepository regionRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private StatusRepository statusRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+	@Autowired
+	private ItemRepository itemRepository;
+
+	@BeforeEach
+	void init() {
+		regions = FixtureFactory.createRegionFixtures(3);
+		regionRepository.saveAll(regions);
+
+		user = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0), regions.get(1)));
+		userRepository.save(user);
+
+		categories = FixtureFactory.createCategoryFixture(3);
+		categoryRepository.saveAll(categories);
+
+		images = FixtureFactory.createImageFixtures(3);
+		imageRepository.saveAll(images);
+
+		statusList = FixtureFactory.createStatusFixtures();
+		statusRepository.saveAll(statusList);
+
+	}
+
+	@DisplayName("새로운 상품 등록을 성공한다.")
+	@Test
+	void postItem() {
+		// given
+		ItemPostingServiceRequest request = new ItemPostingServiceRequest("title", null, "content", images,
+			1L, 1L);
+
+		// when
+		itemService.postItem(request, user.getId());
+		Item postedItem = itemRepository.findDetailById(1L).orElseThrow(NoSuchItemException::new);
+
+		// then
+		assertAll(
+			() -> assertThat(postedItem.getUser().getId()).isEqualTo(user.getId()),
+			() -> assertThat(postedItem.getTitle()).isEqualTo("title"),
+			() -> assertThat(postedItem.getPrice()).isNull(),
+			() -> assertThat(postedItem.getContent()).isEqualTo("content"),
+			() -> assertThat(postedItem.listImage()).hasSize(images.size()),
+			() -> assertThat(postedItem.getCategory().getId()).isEqualTo(1L),
+			() -> assertThat(postedItem.getRegion().getId()).isEqualTo(1L)
+		);
+	}
+
+	@DisplayName("존재하지 않는 사용자가 상품을 등록하면 예외가 발생한다.")
+	@Test
+	void postItemAndThrowUserException() {
+		// given
+		Long wrongUserId = 999L;
+		ItemPostingServiceRequest request = new ItemPostingServiceRequest("title", null, "content", images,
+			1L, 1L);
+
+		// when & then
+		assertThatThrownBy(() -> itemService.postItem(request, wrongUserId))
+			.isInstanceOf(NoSuchUserException.class)
+			.hasMessage("존재하지 않는 사용자입니다");
+
+	}
+
+	@DisplayName("상품 등록 시 존재하지 않는 카테고리를 설정하면 예외가 발생한다.")
+	@Test
+	void postItemAndThrowCategoryException() {
+		// given
+		Long wrongCategoryId = 999L;
+		ItemPostingServiceRequest request = new ItemPostingServiceRequest("title", null, "content", images,
+			wrongCategoryId, 1L);
+
+		// when & then
+		assertThatThrownBy(() -> itemService.postItem(request, user.getId()))
+			.isInstanceOf(NoSuchCategoryException.class)
+			.hasMessage("존재하지 않는 카테고리입니다");
+	}
+
+	@DisplayName("상품 등록 시 존재하지 않는 지역을 설정하면 예외가 발생한다.")
+	@Test
+	void postItemAndThrowRegionException() {
+		// given
+		Long wrongRegionId = 999L;
+		ItemPostingServiceRequest request = new ItemPostingServiceRequest("title", null, "content", images,
+			1L, wrongRegionId);
+
+		// when & then
+		assertThatThrownBy(() -> itemService.postItem(request, user.getId()))
+			.isInstanceOf(NoSuchRegionException.class)
+			.hasMessage("존재하지 않는 동네입니다");
+	}
+
+	@DisplayName("상품 등록 시 나의 동네가 아닌 지역을 설정하면 예외가 발생한다.")
+	@Test
+	void postItemAndThrowMyRegionException() {
+		// given
+		Long notMyRegionId = 3L;
+		ItemPostingServiceRequest request = new ItemPostingServiceRequest("title", null, "content", images,
+			1L, notMyRegionId);
+
+		// when & then
+		assertThatThrownBy(() -> itemService.postItem(request, user.getId()))
+			.isInstanceOf(NoSuchUserRegionException.class)
+			.hasMessage("사용자 동네 목록에 없는 동네입니다");
+	}
+
+}

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -13,27 +14,62 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
 import com.codesquad.secondhand.domain.category.Category;
+import com.codesquad.secondhand.domain.category.CategoryRepository;
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.image.ImageRepository;
 import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.region.RegionRepository;
 import com.codesquad.secondhand.domain.status.Status;
+import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.user.User;
+import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
 
 public class ItemTest extends IntegrationTestSupport {
 
 	@Autowired
+	private ItemRepository itemRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
 	private ImageRepository imageRepository;
+
+	@Autowired
+	private CategoryRepository categoryRepository;
+
+	@Autowired
+	private RegionRepository regionRepository;
+
+	@Autowired
+	private StatusRepository statusRepository;
+
+	private static List<Category> categories;
+	private static List<Region> regions;
+	private static List<Status> statusList;
+	private static User loginUser;
+
+	@BeforeEach
+	void init() {
+		categories = FixtureFactory.createCategoryFixture(3);
+		categoryRepository.saveAll(categories);
+		regions = FixtureFactory.createRegionFixtures(2);
+		regionRepository.saveAll(regions);
+		statusList = FixtureFactory.createStatusFixtures();
+		statusRepository.saveAll(statusList);
+		loginUser = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		userRepository.save(loginUser);
+	}
 
 	@DisplayName("상품 이미지 저장 시나리오")
 	@TestFactory
 	Collection<DynamicTest> addItemImage() {
 		//given
-		List<Category> categories = FixtureFactory.createCategoryFixture(1);
-		List<Region> regions = FixtureFactory.createRegionFixtures(1);
-		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
-		List<Status> statusList = FixtureFactory.createStatusFixtures();
-		Item newItem = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
+
+		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
+		itemRepository.save(newItem);
 
 		return List.of(
 			DynamicTest.dynamicTest("상품 이미지를 저장할 수 있다.", () -> {
@@ -54,11 +90,7 @@ public class ItemTest extends IntegrationTestSupport {
 	@TestFactory
 	Collection<DynamicTest> removeItemImage() {
 		//given
-		List<Category> categories = FixtureFactory.createCategoryFixture(1);
-		List<Region> regions = FixtureFactory.createRegionFixtures(1);
-		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
-		List<Status> statusList = FixtureFactory.createStatusFixtures();
-		Item newItem = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
+		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
 		List<Image> images = FixtureFactory.createImageFixtures(2);
 		imageRepository.saveAll(images);
 
@@ -85,6 +117,38 @@ public class ItemTest extends IntegrationTestSupport {
 
 				//then
 				assertThat(newItem.listImage()).hasSize(1);
+			})
+		);
+	}
+
+	@DisplayName("사용자 권한 여부 확인 시나리오")
+	@TestFactory
+	Collection<DynamicTest> validateSameUser() {
+		// given
+		User otherUser = FixtureFactory.createUserFixtureWithRegions(regions);
+		userRepository.save(otherUser);
+
+		return List.of(
+			DynamicTest.dynamicTest("로그인 사용자와 판매자가 다른 경우 예외를 발생한다.", () -> {
+				// given
+				Item item = FixtureFactory.createItemFixtures(otherUser, categories.get(0), regions.get(0),
+					statusList.get(0));
+
+				// when & then
+				assertThatThrownBy(() -> item.delete(loginUser.getId()))
+					.isInstanceOf(PermissionDeniedException.class)
+					.hasMessage("허가되지 않은 접근입니다");
+			}),
+			DynamicTest.dynamicTest("로그인 사용자와 판매자가 동일한 경우 상품 삭제를 성공한다.", () -> {
+				// given
+				Item item2 = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
+					statusList.get(0));
+
+				// when
+				item2.delete(loginUser.getId());
+
+				// then
+				assertThat(item2.isDeleted()).isTrue();
 			})
 		);
 	}

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -28,83 +29,74 @@ import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
 
 public class ItemTest extends IntegrationTestSupport {
 
-	@Autowired
-	private ItemRepository itemRepository;
-
-	@Autowired
-	private UserRepository userRepository;
-
-	@Autowired
-	private ImageRepository imageRepository;
-
-	@Autowired
-	private CategoryRepository categoryRepository;
-
-	@Autowired
-	private RegionRepository regionRepository;
-
-	@Autowired
-	private StatusRepository statusRepository;
-
 	private static List<Category> categories;
 	private static List<Region> regions;
 	private static List<Status> statusList;
 	private static User loginUser;
+	@Autowired
+	private ItemRepository itemRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private RegionRepository regionRepository;
+	@Autowired
+	private StatusRepository statusRepository;
 
 	@BeforeEach
 	void init() {
-		categories = FixtureFactory.createCategoryFixture(3);
+		categories = FixtureFactory.createCategoryFixtures(3);
 		categoryRepository.saveAll(categories);
 		regions = FixtureFactory.createRegionFixtures(2);
 		regionRepository.saveAll(regions);
 		statusList = FixtureFactory.createStatusFixtures();
 		statusRepository.saveAll(statusList);
-		loginUser = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		loginUser = FixtureFactory.createUserFixture(List.of(regions.get(0)));
 		userRepository.save(loginUser);
 	}
 
-	@DisplayName("상품 이미지 저장 시나리오")
-	@TestFactory
-	Collection<DynamicTest> addItemImage() {
-		//given
-
-		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
+	@DisplayName("상품 이미지 저장을 성공한다.")
+	@Test
+	void addItemImage() {
+		// given
+		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
+			statusList.get(0));
 		itemRepository.save(newItem);
 
-		return List.of(
-			DynamicTest.dynamicTest("상품 이미지를 저장할 수 있다.", () -> {
-				// given
-				List<Image> images = FixtureFactory.createImageFixtures(3);
-				// imageRepository.saveAll(images);
+		List<Image> images = FixtureFactory.createImageFixtures(3);
+		imageRepository.saveAll(images);
 
-				// when
-				newItem.addItemImages(images);
+		// when
+		newItem.addItemImages(images);
 
-				//then
-				assertThat(newItem.listImage()).hasSize(3);
-			})
-		);
+		// then
+		assertThat(newItem.listImage()).hasSize(images.size());
 	}
+
 
 	@DisplayName("상품 이미지 삭제 시나리오")
 	@TestFactory
 	Collection<DynamicTest> removeItemImage() {
 		//given
 		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
-		List<Image> images = FixtureFactory.createImageFixtures(2);
-		imageRepository.saveAll(images);
+		List<Image> itemImages = FixtureFactory.createImageFixtures(2);
+		imageRepository.saveAll(itemImages);
+		List<Image> otherImage = FixtureFactory.createImageFixtures(1);
+		imageRepository.saveAll(otherImage);
 
 		return List.of(
-			DynamicTest.dynamicTest("상품 이미지가 null일 때 삭제하는 경우 예외가 발생한다.", () -> {
+			DynamicTest.dynamicTest("존재하지 않는 상품 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
 				// when & then
-				assertThatThrownBy(() -> newItem.removeItemImage(images.get(0)))
+				assertThatThrownBy(() -> newItem.removeItemImage(itemImages.get(0)))
 					.isInstanceOf(NoSuchItemImageException.class)
 					.hasMessage("존재하지 않는 상품 이미지입니다");
 			}),
-			DynamicTest.dynamicTest("등록하지 않은 상품 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
+			DynamicTest.dynamicTest("현재 상품의 이미지가 아닌 다른 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
 				// given
-				newItem.addItemImages(images);
-				List<Image> otherImage = FixtureFactory.createImageFixtures(1);
+				newItem.addItemImages(itemImages);
 
 				// when & then
 				assertThatThrownBy(() -> newItem.removeItemImage(otherImage.get(0)))
@@ -113,7 +105,7 @@ public class ItemTest extends IntegrationTestSupport {
 			}),
 			DynamicTest.dynamicTest("상품 이미지를 삭제할 수 있다.", () -> {
 				// when
-				newItem.removeItemImage(images.get(0));
+				newItem.removeItemImage(itemImages.get(0));
 
 				//then
 				assertThat(newItem.listImage()).hasSize(1);
@@ -121,36 +113,33 @@ public class ItemTest extends IntegrationTestSupport {
 		);
 	}
 
-	@DisplayName("사용자 권한 여부 확인 시나리오")
+	@DisplayName("상품 삭제 시나리오")
 	@TestFactory
-	Collection<DynamicTest> validateSameUser() {
+	Collection<DynamicTest> deleteItem() {
 		// given
-		User otherUser = FixtureFactory.createUserFixtureWithRegions(regions);
+		User otherUser = FixtureFactory.createUserFixture(regions);
 		userRepository.save(otherUser);
+		Item myItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
+			statusList.get(0));
+		itemRepository.save(myItem);
+		Item otherItem = FixtureFactory.createItemFixtures(otherUser, categories.get(0), regions.get(0),
+			statusList.get(0));
+		itemRepository.save(otherItem);
 
 		return List.of(
-			DynamicTest.dynamicTest("로그인 사용자와 판매자가 다른 경우 예외를 발생한다.", () -> {
-				// given
-				Item item = FixtureFactory.createItemFixtures(otherUser, categories.get(0), regions.get(0),
-					statusList.get(0));
-
-				// when & then
-				assertThatThrownBy(() -> item.delete(loginUser.getId()))
-					.isInstanceOf(PermissionDeniedException.class)
-					.hasMessage("허가되지 않은 접근입니다");
-			}),
-			DynamicTest.dynamicTest("로그인 사용자와 판매자가 동일한 경우 상품 삭제를 성공한다.", () -> {
-				// given
-				Item item2 = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
-					statusList.get(0));
-
+			DynamicTest.dynamicTest("상품 삭제를 성공한다.", () -> {
 				// when
-				item2.delete(loginUser.getId());
+				myItem.delete(loginUser.getId());
 
 				// then
-				assertThat(item2.isDeleted()).isTrue();
+				assertThat(myItem.isDeleted()).isTrue();
+			}),
+			DynamicTest.dynamicTest("상품 삭제 시 로그인 사용자와 판매자가 다른 경우 예외를 발생한다.", () -> {
+				// when & then
+				assertThatThrownBy(() -> otherItem.delete(loginUser.getId()))
+					.isInstanceOf(PermissionDeniedException.class)
+					.hasMessage("허가되지 않은 접근입니다");
 			})
 		);
 	}
-
 }

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -38,7 +38,7 @@ public class ItemTest extends IntegrationTestSupport {
 		return List.of(
 			DynamicTest.dynamicTest("상품 이미지를 저장할 수 있다.", () -> {
 				// given
-				List<Image> images = FixtureFactory.createImageListFixtures(3);
+				List<Image> images = FixtureFactory.createImageFixtures(3);
 				// imageRepository.saveAll(images);
 
 				// when
@@ -59,7 +59,7 @@ public class ItemTest extends IntegrationTestSupport {
 		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
 		List<Status> statusList = FixtureFactory.createStatusFixtures();
 		Item newItem = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
-		List<Image> images = FixtureFactory.createImageListFixtures(2);
+		List<Image> images = FixtureFactory.createImageFixtures(2);
 		imageRepository.saveAll(images);
 
 		return List.of(
@@ -72,7 +72,7 @@ public class ItemTest extends IntegrationTestSupport {
 			DynamicTest.dynamicTest("등록하지 않은 상품 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
 				// given
 				newItem.addItemImages(images);
-				List<Image> otherImage = FixtureFactory.createImageListFixtures(1);
+				List<Image> otherImage = FixtureFactory.createImageFixtures(1);
 
 				// when & then
 				assertThatThrownBy(() -> newItem.removeItemImage(otherImage.get(0)))

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -45,7 +45,7 @@ public class ItemTest extends IntegrationTestSupport {
 				newItem.addItemImages(images);
 
 				//then
-				assertThat(newItem.listItemImage()).hasSize(3);
+				assertThat(newItem.listImage()).hasSize(3);
 			})
 		);
 	}
@@ -84,7 +84,7 @@ public class ItemTest extends IntegrationTestSupport {
 				newItem.removeItemImage(images.get(0));
 
 				//then
-				assertThat(newItem.listItemImage()).hasSize(1);
+				assertThat(newItem.listImage()).hasSize(1);
 			})
 		);
 	}

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -1,0 +1,92 @@
+package com.codesquad.secondhand.domain.item;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.codesquad.secondhand.FixtureFactory;
+import com.codesquad.secondhand.IntegrationTestSupport;
+import com.codesquad.secondhand.domain.category.Category;
+import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.image.ImageRepository;
+import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.status.Status;
+import com.codesquad.secondhand.domain.user.User;
+import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
+
+public class ItemTest extends IntegrationTestSupport {
+
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@DisplayName("상품 이미지 저장 시나리오")
+	@TestFactory
+	Collection<DynamicTest> addItemImage() {
+		//given
+		List<Category> categories = FixtureFactory.createCategoryFixture(1);
+		List<Region> regions = FixtureFactory.createRegionFixtures(1);
+		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		List<Status> statusList = FixtureFactory.createStatusFixtures();
+		Item newItem = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
+
+		return List.of(
+			DynamicTest.dynamicTest("상품 이미지를 저장할 수 있다.", () -> {
+				// given
+				List<Image> images = FixtureFactory.createImageListFixtures(3);
+				// imageRepository.saveAll(images);
+
+				// when
+				newItem.addItemImages(images);
+
+				//then
+				assertThat(newItem.listItemImage()).hasSize(3);
+			})
+		);
+	}
+
+	@DisplayName("상품 이미지 삭제 시나리오")
+	@TestFactory
+	Collection<DynamicTest> removeItemImage() {
+		//given
+		List<Category> categories = FixtureFactory.createCategoryFixture(1);
+		List<Region> regions = FixtureFactory.createRegionFixtures(1);
+		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0)));
+		List<Status> statusList = FixtureFactory.createStatusFixtures();
+		Item newItem = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
+		List<Image> images = FixtureFactory.createImageListFixtures(2);
+		imageRepository.saveAll(images);
+
+		return List.of(
+			DynamicTest.dynamicTest("상품 이미지가 null일 때 삭제하는 경우 예외가 발생한다.", () -> {
+				// when & then
+				assertThatThrownBy(() -> newItem.removeItemImage(images.get(0)))
+					.isInstanceOf(NoSuchItemImageException.class)
+					.hasMessage("존재하지 않는 상품 이미지입니다");
+			}),
+			DynamicTest.dynamicTest("등록하지 않은 상품 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
+				// given
+				newItem.addItemImages(images);
+				List<Image> otherImage = FixtureFactory.createImageListFixtures(1);
+
+				// when & then
+				assertThatThrownBy(() -> newItem.removeItemImage(otherImage.get(0)))
+					.isInstanceOf(NoSuchItemImageException.class)
+					.hasMessage("존재하지 않는 상품 이미지입니다");
+			}),
+			DynamicTest.dynamicTest("상품 이미지를 삭제할 수 있다.", () -> {
+				// when
+				newItem.removeItemImage(images.get(0));
+
+				//then
+				assertThat(newItem.listItemImage()).hasSize(1);
+			})
+		);
+	}
+
+}

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
@@ -3,6 +3,7 @@ package com.codesquad.secondhand.domain.user;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +16,10 @@ import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.image.ImageRepository;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.region.RegionRepository;
+import com.codesquad.secondhand.exception.user_region.DuplicatedUserRegionException;
+import com.codesquad.secondhand.exception.user_region.ExceedUserRegionLimitException;
+import com.codesquad.secondhand.exception.user_region.MinimumUserRegionViolationException;
+import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 
 public class UserTest extends IntegrationTestSupport {
 
@@ -67,6 +72,27 @@ public class UserTest extends IntegrationTestSupport {
 		assertAll(
 			() -> assertThat(user.getNickname()).isEqualTo("newNickname"),
 			() -> assertThat(user.getProfile()).isEqualTo(savedImage)
+		);
+	}
+
+	@DisplayName("새로운 상품 등록 시나리오")
+	@TestFactory
+	Collection<DynamicTest> postItem() {
+		//given
+		List<Region> regions = FixtureFactory.createRegionFixtures(3);
+		regionRepository.saveAll(regions);
+		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0), regions.get(1)));
+
+		return List.of(
+			DynamicTest.dynamicTest("사용자의 동네가 아닌 다른 동네에 새로운 상품을 등록하는 경우 예외가 발생한다.", () -> {
+				//given
+				Region region = regions.get(2);
+
+				//when & then
+				assertThatThrownBy(() -> seller.validateHasRegion(region))
+					.isInstanceOf(NoSuchUserRegionException.class)
+					.hasMessage("사용자 동네 목록에 없는 동네입니다");
+			})
 		);
 	}
 

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
@@ -82,6 +82,7 @@ public class UserTest extends IntegrationTestSupport {
 		List<Region> regions = FixtureFactory.createRegionFixtures(3);
 		regionRepository.saveAll(regions);
 		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0), regions.get(1)));
+		userRepository.save(seller);
 
 		return List.of(
 			DynamicTest.dynamicTest("사용자의 동네가 아닌 다른 동네에 새로운 상품을 등록하는 경우 예외가 발생한다.", () -> {

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
@@ -3,7 +3,6 @@ package com.codesquad.secondhand.domain.user;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -16,9 +15,6 @@ import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.image.ImageRepository;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.region.RegionRepository;
-import com.codesquad.secondhand.exception.user_region.DuplicatedUserRegionException;
-import com.codesquad.secondhand.exception.user_region.ExceedUserRegionLimitException;
-import com.codesquad.secondhand.exception.user_region.MinimumUserRegionViolationException;
 import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 
 public class UserTest extends IntegrationTestSupport {
@@ -75,26 +71,19 @@ public class UserTest extends IntegrationTestSupport {
 		);
 	}
 
-	@DisplayName("새로운 상품 등록 시나리오")
-	@TestFactory
-	Collection<DynamicTest> postItem() {
+	@DisplayName("사용자의 동네가 아닌 다른 동네에 새로운 상품을 등록하는 경우 예외가 발생한다.")
+	@Test
+	void  postItem() {
 		//given
 		List<Region> regions = FixtureFactory.createRegionFixtures(3);
 		regionRepository.saveAll(regions);
-		User seller = FixtureFactory.createUserFixtureWithRegions(List.of(regions.get(0), regions.get(1)));
+		User seller = FixtureFactory.createUserFixture(List.of(regions.get(0), regions.get(1)));
 		userRepository.save(seller);
+		Region region = regions.get(2);
 
-		return List.of(
-			DynamicTest.dynamicTest("사용자의 동네가 아닌 다른 동네에 새로운 상품을 등록하는 경우 예외가 발생한다.", () -> {
-				//given
-				Region region = regions.get(2);
-
-				//when & then
-				assertThatThrownBy(() -> seller.validateHasRegion(region))
-					.isInstanceOf(NoSuchUserRegionException.class)
-					.hasMessage("사용자 동네 목록에 없는 동네입니다");
-			})
-		);
+		assertThatThrownBy(() -> seller.validateHasRegion(region))
+			.isInstanceOf(NoSuchUserRegionException.class)
+			.hasMessage("사용자 동네 목록에 없는 동네입니다");
 	}
 
 }


### PR DESCRIPTION
## Function
- 새로운 상품 등록 API 구현
  - 상품 이미지 등록 API 구현
- 상품 상세 조회 API 구현
- 상품 삭제 API 구현

## Description
- `Item` 객체 생성 시 `AllArugsConstructor` 어노테이션을 쓰지 않고 따로 생성자를 선언했습니다.
  - `wishList`, `chat` 등 파라미터로 넘길 필요 없는 필드가 있어서 변경했습니다.
  - 새리가 말씀하신 것처럼 객체 생성 시 정적 팩토리 메서드나 Build 패턴을 쓰는 걸 생각해봐야 할 것 같아요.
- `Item`의 `List<Image> images` -> `DetailShot detailShot` 일급객체로 빼서 관리하도록 수정했습니다.
- 상품 조회 시 조회수를 증가하는 로직은 추후 추가해야 합니다.
- 현재 로직에서 상품 삭제 시 `Item isDeleted = true`만 되고 `image`는 그대로 두었습니다. 이미지 삭제 관련해서는 다시 의논해야 합니다.


## Discussion
- 상품 등록 시 선택한 지역이 판매자의 나의 동네 목록에 있는지 확인하는 과정에서 validateHasRegion의 위치가 적절한지 고민입니다.
- 삭제 관련 메서드에서 `delete`, `remove`가 혼용되고 있습니다. 하나로 통일하면 좋을 것 같습니다.
- 이전에 제안했던 예외처리 로직은 테스트코드 확인 시 불편할 것 같다는 생각이 들었습니다. 지금 구조를 유지하되, `Handler`만 통일시키는 방법은 어떨까요? [B조 코드](https://github.com/second-hand-team-04/second-hand-max-be-b/blob/dev/src/main/java/com/codesquad/secondhand/common/exception/GlobalExceptionHandler.java) 한 번 봐주시면 감사하겠습니다.

## Test Code
- ItemControllerTest
![image](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/90491fb9-0db2-40bc-81f2-9214c8565035)
삭제 테스트코드는 DTO가 없으므로 따로 검증하지 않았습니다.

- ItemServiceTest
![image](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/60513ef5-06f7-497f-b649-2caf8032b111)

- ItemTest
![image](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/8bba6c00-924b-48bd-8d13-3468d777d487)


테스트코드는 `새로운 상품 등록` / `상품 삭제`에 대해서만 작성했습니다. 나머지는 추후 작성하겠습니다. 그외 테스트코드에서 추가할 부분이 있다면 말씀해주세요😎

추가로 서비스 테스트 코드와 도메인 테스트 코드를 돌릴 때 저만 이렇게 느린가요?ㅠㅠ