### PR TITLE
나의 현재 동네 선택 API 구현 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -20,6 +20,7 @@ public enum ResponseMessage {
 	// User
 	USER_REGION_FETCH_SUCCESS("나의 동네 조회를 성공하였습니다"),
 	USER_REGION_CREATE_SUCCESS("나의 동네 등록을 성공하였습니다"),
+	USER_REGION_SELECT_SUCCESS("나의 동네 선택을 성공하였습니다"),
 	USER_REGION_DELETE_SUCCESS("나의 동네 삭제를 성공하였습니다"),
 	USER_CREATE_SUCCESS("회원가입을 성공하였습니다"),
 	USER_SIGN_IN_SUCCESS("로그인을 성공하였습니다"),

--- a/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +44,12 @@ public class UserRegionController {
 		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.USER_REGION_CREATE_SUCCESS.getMessage());
 	}
 
-	@ResponseStatus(HttpStatus.OK)
+	@PatchMapping("/{id}")
+	public ApiResponse<Void> selectUserRegion(@PathVariable Long id, @SignIn SignInUser signInUser) {
+		userRegionService.selectUserRegion(signInUser.getId(), id);
+		return ApiResponse.noData(HttpStatus.OK, ResponseMessage.USER_REGION_SELECT_SUCCESS.getMessage());
+	}
+
 	@DeleteMapping("/{id}")
 	public ApiResponse<Void> deleteUserRegion(@PathVariable Long id, @SignIn SignInUser signInUser) {
 		userRegionService.deleteUserRegion(signInUser.getId(), id);

--- a/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user_region/UserRegionController.java
@@ -1,7 +1,5 @@
 package com.codesquad.secondhand.api.controller.user_region;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +17,7 @@ import com.codesquad.secondhand.api.ApiResponse;
 import com.codesquad.secondhand.api.ResponseMessage;
 import com.codesquad.secondhand.api.controller.user_region.request.UserRegionCreateRequest;
 import com.codesquad.secondhand.api.service.user_region.UserRegionService;
-import com.codesquad.secondhand.api.service.user_region.response.UserRegionResponse;
+import com.codesquad.secondhand.api.service.user_region.response.UserRegionSelectionResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +29,7 @@ public class UserRegionController {
 	private final UserRegionService userRegionService;
 
 	@GetMapping
-	public ApiResponse<List<UserRegionResponse>> listUserRegions(@SignIn SignInUser signInUser) {
+	public ApiResponse<UserRegionSelectionResponse> listUserRegions(@SignIn SignInUser signInUser) {
 		return ApiResponse.of(HttpStatus.OK, ResponseMessage.USER_REGION_FETCH_SUCCESS.getMessage(),
 			userRegionService.listUserRegions(signInUser.getId()));
 	}

--- a/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
@@ -9,7 +9,6 @@ import com.codesquad.secondhand.api.service.user.request.UserUpdateServiceReques
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
-import com.codesquad.secondhand.domain.user.MyRegion;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.user.UserRepository;
 import com.codesquad.secondhand.exception.auth.SignInFailedException;
@@ -33,16 +32,9 @@ public class UserService {
 		if (userRepository.existsByProviderAndEmail(request.getProvider(), request.getEmail())) {
 			throw new DuplicatedEmailException();
 		}
-		User user = new User(
-			null,
-			new MyRegion(),
-			request.getImage(),
-			request.getProvider(),
-			null,
-			request.getNickname(),
-			request.getEmail(),
-			request.getPassword());
+		User user = request.toEntity();
 		user.addUserRegion(request.getRegion());
+		user.updateSelectedRegion(request.getRegion());
 		return userRepository.save(user);
 	}
 

--- a/src/main/java/com/codesquad/secondhand/api/service/user/request/UserCreateServiceRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/request/UserCreateServiceRequest.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.user.MyRegion;
+import com.codesquad.secondhand.domain.user.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +25,10 @@ public class UserCreateServiceRequest {
 	public static UserCreateServiceRequest from(String email, Provider provider, Region region) {
 		String nickname = UUID.randomUUID().toString().substring(0, 10);
 		return new UserCreateServiceRequest(nickname, email, null, null, provider, region);
+	}
+
+	public User toEntity() {
+		return new User(null, new MyRegion(), image, provider, null, nickname, email, password, null);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/user_region/UserRegionService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user_region/UserRegionService.java
@@ -1,6 +1,5 @@
 package com.codesquad.secondhand.api.service.user_region;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -8,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.codesquad.secondhand.api.service.user_region.request.UserRegionCreateServiceRequest;
 import com.codesquad.secondhand.api.service.user_region.response.UserRegionResponse;
+import com.codesquad.secondhand.api.service.user_region.response.UserRegionSelectionResponse;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.region.RegionRepository;
 import com.codesquad.secondhand.domain.user.User;
@@ -25,12 +25,13 @@ public class UserRegionService {
 	private final RegionRepository regionRepository;
 
 	@Transactional(readOnly = true)
-	public List<UserRegionResponse> listUserRegions(Long userId) {
+	public UserRegionSelectionResponse listUserRegions(Long userId) {
 		User user = userRepository.findCompleteUserById(userId).orElseThrow(NoSuchUserException::new);
-		return user.listUserRegion()
-			.stream()
-			.map(UserRegionResponse::from)
-			.collect(Collectors.toUnmodifiableList());
+		return new UserRegionSelectionResponse(user.getSelectedRegion().getId(),
+			user.listUserRegion()
+				.stream()
+				.map(UserRegionResponse::from)
+				.collect(Collectors.toUnmodifiableList()));
 	}
 
 	@Transactional

--- a/src/main/java/com/codesquad/secondhand/api/service/user_region/UserRegionService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user_region/UserRegionService.java
@@ -43,6 +43,13 @@ public class UserRegionService {
 	}
 
 	@Transactional
+	public void selectUserRegion(Long userId, Long regionId) {
+		User user = userRepository.findCompleteUserById(userId).orElseThrow(NoSuchUserException::new);
+		Region region = regionRepository.findById(regionId).orElseThrow(NoSuchRegionException::new);
+		user.updateSelectedRegion(region);
+	}
+
+	@Transactional
 	public void deleteUserRegion(Long userId, Long regionId) {
 		User user = userRepository.findCompleteUserById(userId).orElseThrow(NoSuchUserException::new);
 		Region region = regionRepository.findById(regionId).orElseThrow(NoSuchRegionException::new);

--- a/src/main/java/com/codesquad/secondhand/api/service/user_region/response/UserRegionSelectionResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user_region/response/UserRegionSelectionResponse.java
@@ -1,0 +1,17 @@
+package com.codesquad.secondhand.api.service.user_region.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserRegionSelectionResponse {
+
+	Long selectedId;
+	List<UserRegionResponse> userRegions;
+
+}

--- a/src/main/java/com/codesquad/secondhand/config/interceptor/SignInInterceptor.java
+++ b/src/main/java/com/codesquad/secondhand/config/interceptor/SignInInterceptor.java
@@ -31,7 +31,7 @@ public class SignInInterceptor implements HandlerInterceptor {
 			return true;
 		}
 
-		if (request.getMethod().equals(HttpMethod.POST.name()) && request.getRequestURI().contains("/api/users")) {
+		if (request.getMethod().equals(HttpMethod.POST.name()) && request.getRequestURI().endsWith("/api/users")) {
 			return true;
 		}
 

--- a/src/main/java/com/codesquad/secondhand/domain/user/MyRegion.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/MyRegion.java
@@ -41,6 +41,13 @@ public class MyRegion {
 		userRegions.remove(validateUserRegion(region));
 	}
 
+	public UserRegion validateUserRegion(Region region) {
+		return userRegions.stream()
+			.filter(r -> r.findRegionId().equals(region.getId()))
+			.findFirst()
+			.orElseThrow(NoSuchUserRegionException::new);
+	}
+
 	private void validateUserRegionLimit() {
 		if (this.userRegions.size() >= MAXIMUM_USER_REGION_COUNT) {
 			throw new ExceedUserRegionLimitException();
@@ -57,13 +64,6 @@ public class MyRegion {
 		if (this.userRegions.size() <= MINIMUM_USER_REGION_COUNT) {
 			throw new MinimumUserRegionViolationException();
 		}
-	}
-
-	private UserRegion validateUserRegion(Region region) {
-		return userRegions.stream()
-			.filter(r -> r.findRegionId().equals(region.getId()))
-			.findFirst()
-			.orElseThrow(NoSuchUserRegionException::new);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -83,23 +83,21 @@ public class User extends BaseTimeEntity {
 	}
 
 	public void validateSameUser(Long targetUserId) {
-		if(!isSameUserAs(targetUserId)) {
+		if (!isSameUserAs(targetUserId)) {
 			throw new PermissionDeniedException();
 		}
 	}
 
-	public boolean isSameUserAs(Long targetUserId){
+	public boolean isSameUserAs(Long targetUserId) {
 		return Objects.equals(this.id, targetUserId);
 	}
 
-	// todo : 위치 확인
 	public void validateHasRegion(Region region) {
-		boolean hasRegion = myRegion.listAll()
+		myRegion.listAll()
 			.stream()
-			.anyMatch(userRegion -> userRegion.getRegion().equals(region));
-		if(!hasRegion) {
-			throw new NoSuchUserRegionException();
-		}
+			.filter(userRegion -> userRegion.findRegionId().equals(region.getId()))
+			.findAny()
+			.orElseThrow(NoSuchUserRegionException::new);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -23,7 +23,6 @@ import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.user_region.UserRegion;
 import com.codesquad.secondhand.domain.wishlist.WishList;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
-import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -61,6 +60,10 @@ public class User extends BaseTimeEntity {
 	private String email;
 	private String password;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "selected_region_id")
+	private Region selectedRegion;
+
 	public String findProfileUrl() {
 		return profile == null ? null : profile.getImageUrl();
 	}
@@ -75,6 +78,11 @@ public class User extends BaseTimeEntity {
 
 	public void removeUserRegion(Region region) {
 		myRegion.removeRegion(region);
+	}
+
+	public void updateSelectedRegion(Region region) {
+		myRegion.validateUserRegion(region);
+		selectedRegion = region;
 	}
 
 	public void updateInformation(String newNickname, Image newProfile) {
@@ -93,11 +101,7 @@ public class User extends BaseTimeEntity {
 	}
 
 	public void validateHasRegion(Region region) {
-		myRegion.listAll()
-			.stream()
-			.filter(userRegion -> userRegion.findRegionId().equals(region.getId()))
-			.findAny()
-			.orElseThrow(NoSuchUserRegionException::new);
+		myRegion.validateUserRegion(region);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/UserRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/UserRepository.java
@@ -9,7 +9,7 @@ import com.codesquad.secondhand.domain.provider.Provider;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	@Query(value = "SELECT u FROM User AS u LEFT JOIN fetch u.myRegion.userRegions AS ur LEFT JOIN fetch ur.region WHERE u.id = :userId")
+	@Query(value = "SELECT u FROM User AS u LEFT JOIN fetch u.myRegion.userRegions AS ur LEFT JOIN fetch ur.region LEFT JOIN FETCH u.selectedRegion WHERE u.id = :userId")
 	Optional<User> findCompleteUserById(Long userId);
 
 	Optional<User> findByEmailAndPassword(String email, String password);

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -38,14 +38,14 @@ public abstract class FixtureFactory {
 
 	public static User createUserFixture(List<Region> regions) {
 		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, "nickname", "test@email.com",
-			"password123!", null);
+			"password123!", regions.get(0));
 		regions.forEach(user::addUserRegion);
 		return user;
 	}
 
 	public static User createUserFixture(List<Region> regions, String nickname, String email) {
 		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, nickname, email,
-			"password123!", null);
+			"password123!", regions.get(0));
 		regions.forEach(user::addUserRegion);
 		return user;
 	}

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -38,14 +38,14 @@ public abstract class FixtureFactory {
 
 	public static User createUserFixture(List<Region> regions) {
 		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, "nickname", "test@email.com",
-			"password123!");
+			"password123!", null);
 		regions.forEach(user::addUserRegion);
 		return user;
 	}
 
 	public static User createUserFixture(List<Region> regions, String nickname, String email) {
 		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, nickname, email,
-			"password123!");
+			"password123!", null);
 		regions.forEach(user::addUserRegion);
 		return user;
 	}

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
@@ -3,10 +3,13 @@ package com.codesquad.secondhand.domain.user;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.codesquad.secondhand.FixtureFactory;
@@ -50,7 +53,7 @@ public class UserTest extends IntegrationTestSupport {
 
 	@DisplayName("사용자의 닉네임과 프로필을 수정한다.")
 	@Test
-	void updateNickname() {
+	void updateInformation() {
 		// given
 		List<Region> regions = FixtureFactory.createRegionFixtures(1);
 		regionRepository.saveAll(regions);
@@ -71,9 +74,43 @@ public class UserTest extends IntegrationTestSupport {
 		);
 	}
 
+	@DisplayName("사용자 동네 선택 시나리오")
+	@TestFactory
+	Collection<DynamicTest> updateSelectedRegion() {
+		// given
+		List<Region> regions = FixtureFactory.createRegionFixtures(2);
+		regionRepository.saveAll(regions);
+
+		User user = FixtureFactory.createUserFixture(List.of(regions.get(0)));
+		User savedUser = userRepository.save(user);
+
+		return List.of(
+			DynamicTest.dynamicTest("사용자 등록 시 기본 동네를 자동으로 선택한다.", () -> {
+				// when & then
+				assertThat(savedUser.getSelectedRegion()).isEqualTo(regions.get(0));
+			}),
+			DynamicTest.dynamicTest("사용자 동네에 없는 동네를 선택하려고 시도하는 경우 에러가 발생한다.", () -> {
+				// when & then
+				assertThatThrownBy(() -> savedUser.updateSelectedRegion(regions.get(1)))
+					.isInstanceOf(NoSuchUserRegionException.class)
+					.hasMessage("사용자 동네 목록에 없는 동네입니다");
+			}),
+			DynamicTest.dynamicTest("사용자 목록에 있는 동네를 선택할 수 있다.", () -> {
+				// given
+				user.addUserRegion(regions.get(1));
+
+				// when
+				savedUser.updateSelectedRegion(regions.get(1));
+
+				//then
+				assertThat(savedUser.getSelectedRegion()).isEqualTo(regions.get(1));
+			})
+		);
+	}
+
 	@DisplayName("사용자의 동네가 아닌 다른 동네에 새로운 상품을 등록하는 경우 예외가 발생한다.")
 	@Test
-	void  postItem() {
+	void postItem() {
 		//given
 		List<Region> regions = FixtureFactory.createRegionFixtures(3);
 		regionRepository.saveAll(regions);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -17,6 +17,13 @@ CREATE TABLE `image`
     PRIMARY KEY (`id`)
 );
 
+CREATE TABLE region
+(
+    id    BIGINT AUTO_INCREMENT,
+    title VARCHAR(30) NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
 CREATE TABLE user
 (
     id          BIGINT AUTO_INCREMENT,
@@ -26,9 +33,11 @@ CREATE TABLE user
     password    VARCHAR(150),
     created_at  TIMESTAMP    NOT NULL,
     provider_id BIGINT       NOT NULL,
+    selected_region_id    BIGINT,
     PRIMARY KEY (`id`),
     FOREIGN KEY (image_id) REFERENCES image (id),
-    FOREIGN KEY (provider_id) REFERENCES provider (id)
+    FOREIGN KEY (provider_id) REFERENCES provider (id),
+    FOREIGN KEY (selected_region_id) REFERENCES region (id)
 );
 
 CREATE TABLE refresh_token
@@ -52,13 +61,6 @@ CREATE TABLE status
 (
     id   BIGINT AUTO_INCREMENT,
     type VARCHAR(20) NOT NULL,
-    PRIMARY KEY (`id`)
-);
-
-CREATE TABLE region
-(
-    id    BIGINT AUTO_INCREMENT,
-    title VARCHAR(30) NOT NULL,
     PRIMARY KEY (`id`)
 );
 


### PR DESCRIPTION
## Description

**PATCH** `/api/users/regions/{id}`

현재 동네를 선택하는 API 구현을 완료했습니다.
사용자 등록 시, 기본 동네 설정과 함께 기본 선택 동네도 함께 설정합니다.

- selectedId를 포함하도록 응답 형태를 수정했습니다.

<img width="425" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/c9638a06-9fec-40a7-9789-88d669ecc4ec">

(사용자 동네 목록에 없는 동네를 선택하려는 경우에 대한 예외 처리를 구현했습니다.)

Closes #50 