### PR TITLE
관심 목록 관련 API 구현 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
+++ b/src/main/java/com/codesquad/secondhand/api/ResponseMessage.java
@@ -29,7 +29,12 @@ public enum ResponseMessage {
 	USER_INFORMATION_UPDATE_SUCCESS("사용자 정보 수정을 성공하였습니다"),
 
 	// Image
-	MAXIMUM_UPLOAD_SIZE_EXCEEDED("업로드 가능한 파일의 최대 크기를 초과했습니다");
+	MAXIMUM_UPLOAD_SIZE_EXCEEDED("업로드 가능한 파일의 최대 크기를 초과했습니다"),
+
+	// Wishlist
+	WISHLIST_FETCH_SUCCESS("관심목록 조회를 성공하였습니다"),
+	WISHLIST_CREATE_SUCCESS("관심목록 추가를 성공하였습니다"),
+	WISHLIST_DELETE_SUCCESS("관심목록 삭제를 성공하였습니다");
 
 	private final String message;
 

--- a/src/main/java/com/codesquad/secondhand/api/controller/wishlist/WishlistController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/wishlist/WishlistController.java
@@ -1,0 +1,48 @@
+package com.codesquad.secondhand.api.controller.wishlist;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codesquad.secondhand.annotation.SignIn;
+import com.codesquad.secondhand.annotation.SignInUser;
+import com.codesquad.secondhand.api.ApiResponse;
+import com.codesquad.secondhand.api.ResponseMessage;
+import com.codesquad.secondhand.api.service.wishlist.WishlistService;
+import com.codesquad.secondhand.api.service.wishlist.response.WishlistSliceResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/users/wishlist")
+@RequiredArgsConstructor
+@RestController
+public class WishlistController {
+
+	private final WishlistService wishlistService;
+
+	@GetMapping
+	public ApiResponse<WishlistSliceResponse> listWishlists(@SignIn SignInUser signInUser, Pageable pageable) {
+		return ApiResponse.of(HttpStatus.OK, ResponseMessage.WISHLIST_FETCH_SUCCESS.getMessage(),
+			wishlistService.listWishlists(signInUser.getId(), pageable));
+	}
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("/{itemId}")
+	public ApiResponse<Void> createWishlist(@PathVariable Long itemId, @SignIn SignInUser signInUser) {
+		wishlistService.createWishlist(signInUser.getId(), itemId);
+		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.WISHLIST_CREATE_SUCCESS.getMessage());
+	}
+
+	@DeleteMapping("/{itemId}")
+	public ApiResponse<Void> deleteWishlist(@PathVariable Long itemId, @SignIn SignInUser signInUser) {
+		wishlistService.deleteWishlist(signInUser.getId(), itemId);
+		return ApiResponse.noData(HttpStatus.OK, ResponseMessage.WISHLIST_DELETE_SUCCESS.getMessage());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/service/user/request/UserCreateServiceRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/request/UserCreateServiceRequest.java
@@ -6,6 +6,7 @@ import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.user.MyRegion;
+import com.codesquad.secondhand.domain.user.MyWishlist;
 import com.codesquad.secondhand.domain.user.User;
 
 import lombok.AllArgsConstructor;
@@ -28,7 +29,7 @@ public class UserCreateServiceRequest {
 	}
 
 	public User toEntity() {
-		return new User(null, new MyRegion(), image, provider, null, nickname, email, password, null);
+		return new User(null, new MyRegion(), image, provider, new MyWishlist(), nickname, email, password, null);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/WishlistService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/WishlistService.java
@@ -1,0 +1,55 @@
+package com.codesquad.secondhand.api.service.wishlist;
+
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codesquad.secondhand.api.service.wishlist.response.WishlistResponse;
+import com.codesquad.secondhand.api.service.wishlist.response.WishlistSliceResponse;
+import com.codesquad.secondhand.domain.item.Item;
+import com.codesquad.secondhand.domain.item.ItemRepository;
+import com.codesquad.secondhand.domain.user.User;
+import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.domain.wishlist.Wishlist;
+import com.codesquad.secondhand.domain.wishlist.WishlistRepository;
+import com.codesquad.secondhand.exception.item.NoSuchItemException;
+import com.codesquad.secondhand.exception.user.NoSuchUserException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class WishlistService {
+
+	private final WishlistRepository wishlistRepository;
+	private final UserRepository userRepository;
+	private final ItemRepository itemRepository;
+
+	@Transactional(readOnly = true)
+	public WishlistSliceResponse listWishlists(Long userId, Pageable pageable) {
+		Slice<Wishlist> items = wishlistRepository.findSliceByUserId(pageable, userId);
+
+		return new WishlistSliceResponse(items.hasNext(), items
+			.stream()
+			.map(WishlistResponse::from)
+			.collect(Collectors.toUnmodifiableList()));
+	}
+
+	@Transactional
+	public void createWishlist(Long userId, Long itemId) {
+		User user = userRepository.findCompleteUserById(userId).orElseThrow(NoSuchUserException::new);
+		Item item = itemRepository.findById(itemId).orElseThrow(NoSuchItemException::new);
+		user.addWishlist(item);
+	}
+
+	@Transactional
+	public void deleteWishlist(Long userId, Long itemId) {
+		User user = userRepository.findCompleteUserById(userId).orElseThrow(NoSuchUserException::new);
+		Item item = itemRepository.findById(itemId).orElseThrow(NoSuchItemException::new);
+		user.removeWishlist(item);
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
@@ -1,0 +1,40 @@
+package com.codesquad.secondhand.api.service.wishlist.response;
+
+import java.time.LocalDateTime;
+
+import com.codesquad.secondhand.domain.wishlist.Wishlist;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class WishlistResponse {
+
+	private Long id;
+	private String title;
+	private String region;
+	private String status;
+	private String thumbnailUrl;
+	private LocalDateTime updatedAt;
+	private int price;
+	private int numChat;
+	private int numLikes;
+
+	public static WishlistResponse from(Wishlist wishlist) {
+		return new WishlistResponse(
+			wishlist.getItem().getId(),
+			wishlist.getItem().getTitle(),
+			wishlist.getItem().getRegion().getTitle(),
+			wishlist.getItem().getStatus().getType(),
+			!wishlist.getItem().getDetailShot().listAllImages().isEmpty() ?
+				wishlist.getItem().getDetailShot().listAllImages().get(0).getImageUrl() : null,
+			wishlist.getItem().getUpdatedAt(),
+			wishlist.getItem().getPrice(),
+			wishlist.getItem().getNumChat(),
+			wishlist.getItem().getPrice());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistSliceResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistSliceResponse.java
@@ -1,0 +1,15 @@
+package com.codesquad.secondhand.api.service.wishlist.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WishlistSliceResponse {
+
+	private boolean hasMore;
+	private List<WishlistResponse> items;
+
+}

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -25,7 +25,7 @@ import com.codesquad.secondhand.domain.item_image.ItemImage;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.user.User;
-import com.codesquad.secondhand.domain.wishlist.WishList;
+import com.codesquad.secondhand.domain.wishlist.Wishlist;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -62,7 +62,7 @@ public class Item extends BaseTimeEntity {
 	private DetailShot detailShot;
 
 	@OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
-	private List<WishList> wishLists = new ArrayList<>();
+	private List<Wishlist> wishLists = new ArrayList<>();
 
 	@OneToMany(mappedBy = "item")
 	private List<Chat> chats = new ArrayList<>();
@@ -110,7 +110,7 @@ public class Item extends BaseTimeEntity {
 	}
 
 	public void addItemImages(List<Image> images) {
-		for(Image image : images) {
+		for (Image image : images) {
 			detailShot.addImage(new ItemImage(null, this, image));
 		}
 	}

--- a/src/main/java/com/codesquad/secondhand/domain/item/QueryItemRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/QueryItemRepository.java
@@ -5,7 +5,7 @@ import static com.codesquad.secondhand.domain.image.QImage.*;
 import static com.codesquad.secondhand.domain.item.QItem.*;
 import static com.codesquad.secondhand.domain.item_image.QItemImage.*;
 import static com.codesquad.secondhand.domain.region.QRegion.*;
-import static com.codesquad.secondhand.domain.wishlist.QWishList.*;
+import static com.codesquad.secondhand.domain.wishlist.QWishlist.*;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class QueryItemRepository {
 				item.updatedAt,
 				item.price,
 				chat.countDistinct(),
-				wishList.countDistinct()
+				wishlist.countDistinct()
 
 			))
 			.from(item)
@@ -52,7 +52,7 @@ public class QueryItemRepository {
 			.leftJoin(item.detailShot.itemImages, itemImage)
 			.leftJoin(itemImage.image, image)
 			.leftJoin(item.chats, chat)
-			.leftJoin(item.wishLists, wishList)
+			.leftJoin(item.wishLists, wishlist)
 			.groupBy(
 				item.id,
 				item.title,
@@ -79,7 +79,7 @@ public class QueryItemRepository {
 
 	private Slice<ItemResponse> checkLastPage(int pageSize, List<ItemResponse> itemList) {
 		boolean hasNext = false;
-		if(itemList.size() > pageSize) {
+		if (itemList.size() > pageSize) {
 			hasNext = true;
 			itemList.remove(pageSize);
 		}

--- a/src/main/java/com/codesquad/secondhand/domain/user/MyWishlist.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/MyWishlist.java
@@ -1,0 +1,50 @@
+package com.codesquad.secondhand.domain.user;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+import com.codesquad.secondhand.domain.item.Item;
+import com.codesquad.secondhand.domain.wishlist.Wishlist;
+import com.codesquad.secondhand.exception.wishlist.DuplicatedWishlistException;
+import com.codesquad.secondhand.exception.wishlist.NoSuchWishlistException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Embeddable
+public class MyWishlist {
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private final List<Wishlist> wishlists = new ArrayList<>();
+
+	public List<Wishlist> listAll() {
+		return List.copyOf(wishlists);
+	}
+
+	public void addWishList(Wishlist wishlist) {
+		validateDuplicateWishlist(wishlist);
+		wishlists.add(wishlist);
+	}
+
+	public void removeWishList(Item item) {
+		wishlists.remove(validateWishlist(item));
+	}
+
+	private Wishlist validateWishlist(Item item) {
+		return wishlists.stream()
+			.filter(wishlist -> wishlist.getItem().getId().equals(item.getId()))
+			.findFirst()
+			.orElseThrow(NoSuchWishlistException::new);
+	}
+
+	private void validateDuplicateWishlist(Wishlist wishlist) {
+		if (this.wishlists.stream().anyMatch(w -> w.getItem().equals(wishlist.getItem()))) {
+			throw new DuplicatedWishlistException();
+		}
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/domain/user/User.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/User.java
@@ -1,10 +1,8 @@
 package com.codesquad.secondhand.domain.user;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,15 +11,15 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import com.codesquad.secondhand.domain.image.Image;
+import com.codesquad.secondhand.domain.item.Item;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.user_region.UserRegion;
-import com.codesquad.secondhand.domain.wishlist.WishList;
+import com.codesquad.secondhand.domain.wishlist.Wishlist;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.util.BaseTimeEntity;
 
@@ -52,9 +50,8 @@ public class User extends BaseTimeEntity {
 	@JoinColumn(name = "provider_id")
 	private Provider provider;
 
-	// TODO: MyWishList와 같이 일급 객체로 리팩토링
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-	private List<WishList> wishLists = new ArrayList<>();
+	@Embedded
+	private MyWishlist myWishlist;
 
 	private String nickname;
 	private String email;
@@ -102,6 +99,14 @@ public class User extends BaseTimeEntity {
 
 	public void validateHasRegion(Region region) {
 		myRegion.validateUserRegion(region);
+	}
+
+	public void addWishlist(Item item) {
+		myWishlist.addWishList(new Wishlist(null, this, item));
+	}
+
+	public void removeWishlist(Item item) {
+		myWishlist.removeWishList(item);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/user/UserRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/user/UserRepository.java
@@ -9,7 +9,11 @@ import com.codesquad.secondhand.domain.provider.Provider;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	@Query(value = "SELECT u FROM User AS u LEFT JOIN fetch u.myRegion.userRegions AS ur LEFT JOIN fetch ur.region LEFT JOIN FETCH u.selectedRegion WHERE u.id = :userId")
+	@Query(value = "SELECT u FROM User AS u "
+		+ "LEFT JOIN fetch u.myRegion.userRegions AS ur "
+		+ "LEFT JOIN fetch ur.region "
+		+ "LEFT JOIN fetch u.selectedRegion "
+		+ "WHERE u.id = :userId")
 	Optional<User> findCompleteUserById(Long userId);
 
 	Optional<User> findByEmailAndPassword(String email, String password);

--- a/src/main/java/com/codesquad/secondhand/domain/wishlist/Wishlist.java
+++ b/src/main/java/com/codesquad/secondhand/domain/wishlist/Wishlist.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "wishlist")
-public class WishList {
+public class Wishlist {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/codesquad/secondhand/domain/wishlist/WishlistRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/wishlist/WishlistRepository.java
@@ -1,0 +1,19 @@
+package com.codesquad.secondhand.domain.wishlist;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
+	@Query(value = "SELECT w FROM Wishlist AS w "
+		+ "LEFT JOIN fetch w.item AS wi "
+		+ "JOIN fetch wi.region "
+		+ "JOIN fetch wi.status "
+		+ "LEFT JOIN fetch wi.detailShot.itemImages "
+		+ "WHERE w.user.id = :userId "
+		+ "AND wi.isDeleted = 0 ")
+	Slice<Wishlist> findSliceByUserId(Pageable pageable, Long userId);
+
+}

--- a/src/main/java/com/codesquad/secondhand/exception/wishlist/DuplicatedWishlistException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/wishlist/DuplicatedWishlistException.java
@@ -1,0 +1,11 @@
+package com.codesquad.secondhand.exception.wishlist;
+
+public class DuplicatedWishlistException extends RuntimeException {
+
+	private static final String MESSAGE = "이미 관심 목록에 담은 상품입니다";
+
+	public DuplicatedWishlistException() {
+		super(MESSAGE);
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/exception/wishlist/NoSuchWishlistException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/wishlist/NoSuchWishlistException.java
@@ -1,0 +1,11 @@
+package com.codesquad.secondhand.exception.wishlist;
+
+public class NoSuchWishlistException extends RuntimeException {
+
+	private static final String MESSAGE = "관심 목록에 없는 상품입니다";
+
+	public NoSuchWishlistException() {
+		super(MESSAGE);
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/exception/wishlist/WishlistExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/wishlist/WishlistExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.codesquad.secondhand.exception.wishlist;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.codesquad.secondhand.api.ApiResponse;
+
+@RestControllerAdvice
+public class WishlistExceptionHandler {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler({DuplicatedWishlistException.class, NoSuchWishlistException.class})
+	public ApiResponse<Void> handleWishlistException(RuntimeException exception) {
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, exception.getMessage());
+	}
+
+}

--- a/src/test/java/com/codesquad/secondhand/FixtureFactory.java
+++ b/src/test/java/com/codesquad/secondhand/FixtureFactory.java
@@ -12,6 +12,7 @@ import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
 import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.user.MyRegion;
+import com.codesquad.secondhand.domain.user.MyWishlist;
 import com.codesquad.secondhand.domain.user.User;
 
 public abstract class FixtureFactory {
@@ -37,14 +38,8 @@ public abstract class FixtureFactory {
 	}
 
 	public static User createUserFixture(List<Region> regions) {
-		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, "nickname", "test@email.com",
-			"password123!", regions.get(0));
-		regions.forEach(user::addUserRegion);
-		return user;
-	}
-
-	public static User createUserFixture(List<Region> regions, String nickname, String email) {
-		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), null, nickname, email,
+		User user = new User(null, new MyRegion(), null, Provider.ofLocal(), new MyWishlist(), "nickname",
+			"test@email.com",
 			"password123!", regions.get(0));
 		regions.forEach(user::addUserRegion);
 		return user;
@@ -56,7 +51,7 @@ public abstract class FixtureFactory {
 			.collect(Collectors.toList());
 	}
 
-	public static Item createItemFixtures(User user, Category category, Region region, Status status) {
+	public static Item createItemFixture(User user, Category category, Region region, Status status) {
 		return new Item(user, category, region, status, LOCAL_DATE_TIME, "title", "content", null);
 	}
 

--- a/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
@@ -166,7 +166,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// given
 		User seller = FixtureFactory.createUserFixture(List.of(regions.get(0)));
 		userRepository.save(seller);
-		Item item = FixtureFactory.createItemFixtures(seller, categories.get(0), regions.get(0), statusList.get(0));
+		Item item = FixtureFactory.createItemFixture(seller, categories.get(0), regions.get(0), statusList.get(0));
 		item.addItemImages(images);
 		itemRepository.save(item);
 
@@ -206,7 +206,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 	@Test
 	void deleteItem() {
 		// given
-		Item item = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
+		Item item = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0), statusList.get(0));
 		itemRepository.save(item);
 
 		// when
@@ -223,7 +223,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// given
 		User otheruser = FixtureFactory.createUserFixture(List.of(regions.get(0)));
 		userRepository.save(otheruser);
-		Item item = FixtureFactory.createItemFixtures(otheruser, categories.get(0), regions.get(0), statusList.get(0));
+		Item item = FixtureFactory.createItemFixture(otheruser, categories.get(0), regions.get(0), statusList.get(0));
 		itemRepository.save(item);
 
 		// when & then

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -62,7 +62,7 @@ public class ItemTest extends IntegrationTestSupport {
 	@Test
 	void addItemImage() {
 		// given
-		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
+		Item newItem = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0),
 			statusList.get(0));
 		itemRepository.save(newItem);
 
@@ -76,12 +76,12 @@ public class ItemTest extends IntegrationTestSupport {
 		assertThat(newItem.listImage()).hasSize(images.size());
 	}
 
-
 	@DisplayName("상품 이미지 삭제 시나리오")
 	@TestFactory
 	Collection<DynamicTest> removeItemImage() {
 		//given
-		Item newItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0), statusList.get(0));
+		Item newItem = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0),
+			statusList.get(0));
 		List<Image> itemImages = FixtureFactory.createImageFixtures(2);
 		imageRepository.saveAll(itemImages);
 		List<Image> otherImage = FixtureFactory.createImageFixtures(1);
@@ -119,10 +119,10 @@ public class ItemTest extends IntegrationTestSupport {
 		// given
 		User otherUser = FixtureFactory.createUserFixture(regions);
 		userRepository.save(otherUser);
-		Item myItem = FixtureFactory.createItemFixtures(loginUser, categories.get(0), regions.get(0),
+		Item myItem = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0),
 			statusList.get(0));
 		itemRepository.save(myItem);
-		Item otherItem = FixtureFactory.createItemFixtures(otherUser, categories.get(0), regions.get(0),
+		Item otherItem = FixtureFactory.createItemFixture(otherUser, categories.get(0), regions.get(0),
 			statusList.get(0));
 		itemRepository.save(otherItem);
 

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserRegionTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserRegionTest.java
@@ -111,4 +111,38 @@ class UserRegionTest extends IntegrationTestSupport {
 		);
 	}
 
+	@DisplayName("사용자 동네 선택 시나리오")
+	@TestFactory
+	Collection<DynamicTest> updateSelectedRegion() {
+		// given
+		List<Region> regions = FixtureFactory.createRegionFixtures(2);
+		regionRepository.saveAll(regions);
+
+		User user = FixtureFactory.createUserFixture(List.of(regions.get(0)));
+		User savedUser = userRepository.save(user);
+
+		return List.of(
+			DynamicTest.dynamicTest("사용자 등록 시 기본 동네를 자동으로 선택한다.", () -> {
+				// when & then
+				assertThat(savedUser.getSelectedRegion()).isEqualTo(regions.get(0));
+			}),
+			DynamicTest.dynamicTest("사용자 동네에 없는 동네를 선택하려고 시도하는 경우 에러가 발생한다.", () -> {
+				// when & then
+				assertThatThrownBy(() -> savedUser.updateSelectedRegion(regions.get(1)))
+					.isInstanceOf(NoSuchUserRegionException.class)
+					.hasMessage("사용자 동네 목록에 없는 동네입니다");
+			}),
+			DynamicTest.dynamicTest("사용자 목록에 있는 동네를 선택할 수 있다.", () -> {
+				// given
+				user.addUserRegion(regions.get(1));
+
+				// when
+				savedUser.updateSelectedRegion(regions.get(1));
+
+				//then
+				assertThat(savedUser.getSelectedRegion()).isEqualTo(regions.get(1));
+			})
+		);
+	}
+
 }


### PR DESCRIPTION
## Description

- Item을 관심 목록에 추가하는 API 구현 (**POST** api/users/wishlist/{itemId})
- Item을 관심 목록 제거하는 API 구현 (**DELETE** api/users/wishlist/{itemId})
- 사용자의 관심 목록을 응답하는 API 구현 (**GET** api/users/wishlist)

## Considerations

1. 상품이 삭제되면 목록에서 보이지 않습니다.
2. 자신의 상품도 관심 목록에 추가할 수 있습니다.
3. 관심 목록 또한 Pageable을 받아 Slice 처리되어 응답합니다.
4. 이미 추가한 상품을 중복하여 추가할 수 없습니다.
5. `Wishlist`와 `WishList` 중 `Wishlist`로 통일하였습니다.

6. `List<>`를 여러 개 갖고 있는 경우 fetch join을 사용하여 한 번에 가져오는 게 힘들어 크게 한 번, 그리고 남은 것 한 번 이렇게 가져오고 있습니다.

**실행 쿼리**
<img width="316"  src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/997bc8ec-c2f6-4caa-bba1-2b55fee67c4b">

<img width="319" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/74b86ccd-4cf7-461b-9b9a-731ffce7bc1d">

**응답 결과**
<img width="444" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/a4fc51a1-18a9-403c-a0c7-330126a20d1f">


Closes #54 