### PR TITLE
Refactor/#66 refactoring

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -1,5 +1,7 @@
 package com.codesquad.secondhand.api.controller.item;
 
+import javax.validation.Valid;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -48,7 +50,7 @@ public class ItemController {
 
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
-	public ApiResponse<Void> postItem(@RequestBody ItemPostRequest request, @SignIn SignInUser signInUser) {
+	public ApiResponse<Void> postItem(@RequestBody @Valid ItemPostRequest request, @SignIn SignInUser signInUser) {
 		itemService.postItem(request.toService(imageService.findImagesByIds(request.getImageIds())),
 			signInUser.getId());
 		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage());

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostRequest.java
@@ -2,6 +2,12 @@ package com.codesquad.secondhand.api.controller.item.request;
 
 import java.util.List;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.constraints.Length;
+
 import com.codesquad.secondhand.api.service.item.request.ItemPostServiceRequest;
 import com.codesquad.secondhand.domain.image.Image;
 
@@ -14,11 +20,23 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ItemPostRequest {
 
+	@NotBlank(message = "제목은 공백일 수 없습니다")
+	@Length(max = 60, message = "제목은 최대 60자 입니다")
 	private String title;
+
 	private Integer price;
+
+	@NotBlank(message = "내용은 공백일 수 없습니다")
+	@Length(max = 3000, message = "내용은 최대 3000자 입니다")
 	private String content;
+
+	@Size(max = 10, message = "상품 이미지는 최대 10개까지 등록할 수 있습니다")
 	private List<Long> imageIds;
+
+	@NotNull(message = "상품 카테고리가 선택되지 않았습니다")
 	private Long categoryId;
+
+	@NotNull(message = "지역이 선택되지 않았습니다")
 	private Long regionId;
 
 	public ItemPostServiceRequest toService(List<Image> images) {

--- a/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
@@ -18,7 +18,6 @@ public class ItemResponse {
 	private String status;
 	private Long sellerId;
 	private String thumbnail;
-	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	private Integer price;
 	private int numChat;
@@ -33,7 +32,6 @@ public class ItemResponse {
 			item.getUser().getId(),
 			item.getThumbnailUrl(),
 			item.getCreatedAt(),
-			item.getUpdatedAt(),
 			item.getPrice(),
 			item.getNumChat(),
 			item.getNumLikes()

--- a/src/main/java/com/codesquad/secondhand/api/service/user/response/UserTransactionResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/response/UserTransactionResponse.java
@@ -1,28 +1,47 @@
 package com.codesquad.secondhand.api.service.user.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import com.codesquad.secondhand.domain.item.DetailShot;
+import com.codesquad.secondhand.domain.item.Item;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class UserTransactionResponse {
 
 	private Long id;
 	private String title;
 	private String region;
-	private DetailShot detailShot;
+	private String status;
+	private Long sellerId;
+	private String thumbnail;
 	private LocalDateTime updatedAt;
 	private Integer price;
+	private int numChat;
+	private int numLikes;
 
-	public UserTransactionResponse(Long id, String title, String region, DetailShot detailShot, LocalDateTime updatedAt,
-		Integer price) {
-		this.id = id;
-		this.title = title;
-		this.region = region;
-		this.detailShot = detailShot;
-		this.updatedAt = updatedAt;
-		this.price = price;
+	public static UserTransactionResponse from(Item item) {
+		return new UserTransactionResponse(
+			item.getId(),
+			item.getTitle(),
+			item.getRegion().getTitle(),
+			item.getStatus().getType(),
+			item.getUser().getId(),
+			item.getThumbnailUrl(),
+			item.getCreatedAt(),
+			item.getPrice(),
+			item.getNumChat(),
+			item.getNumLikes()
+		);
+	}
+
+	public static List<UserTransactionResponse> from(List<Item> items) {
+		return items.stream()
+			.map(UserTransactionResponse::from)
+			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
@@ -17,24 +17,25 @@ public class WishlistResponse {
 	private String title;
 	private String region;
 	private String status;
+	private Long sellerId;
 	private String thumbnailUrl;
 	private LocalDateTime updatedAt;
-	private int price;
+	private Integer price;
 	private int numChat;
 	private int numLikes;
 
 	public static WishlistResponse from(Wishlist wishlist) {
 		return new WishlistResponse(
-			wishlist.getItem().getId(),
-			wishlist.getItem().getTitle(),
-			wishlist.getItem().getRegion().getTitle(),
-			wishlist.getItem().getStatus().getType(),
-			!wishlist.getItem().getDetailShot().listAllImages().isEmpty() ?
-				wishlist.getItem().getDetailShot().listAllImages().get(0).getImageUrl() : null,
-			wishlist.getItem().getUpdatedAt(),
-			wishlist.getItem().getPrice(),
-			wishlist.getItem().getNumChat(),
-			wishlist.getItem().getPrice());
+			wishlist.getItemId(),
+			wishlist.getItemTitle(),
+			wishlist.getItemRegionTitle(),
+			wishlist.getItemStatusType(),
+			wishlist.getItemSellerId(),
+			wishlist.getItemThumbnailUrl(),
+			wishlist.getItemUpdatedAt(),
+			wishlist.getItemPrice(),
+			wishlist.getItemNumChat(),
+			wishlist.getItemNumLikes());
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/domain/wishlist/Wishlist.java
+++ b/src/main/java/com/codesquad/secondhand/domain/wishlist/Wishlist.java
@@ -1,5 +1,7 @@
 package com.codesquad.secondhand.domain.wishlist;
 
+import java.time.LocalDateTime;
+
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -35,5 +37,45 @@ public class Wishlist {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "item_id")
 	private Item item;
+
+	public Long getItemId() {
+		return this.item.getId();
+	}
+
+	public String getItemTitle() {
+		return this.item.getTitle();
+	}
+
+	public Long getItemSellerId() {
+		return this.item.getUser().getId();
+	}
+
+	public String getItemRegionTitle() {
+		return this.item.getRegion().getTitle();
+	}
+
+	public String getItemStatusType() {
+		return this.item.getStatus().getType();
+	}
+
+	public String getItemThumbnailUrl() {
+		return this.item.getThumbnailUrl();
+	}
+
+	public LocalDateTime getItemUpdatedAt() {
+		return this.item.getUpdatedAt();
+	}
+
+	public Integer getItemPrice() {
+		return this.item.getPrice();
+	}
+
+	public int getItemNumChat() {
+		return this.item.getNumChat();
+	}
+
+	public int getItemNumLikes() {
+		return this.item.getNumLikes();
+	}
 
 }


### PR DESCRIPTION
## Description
- 홈화면 상품조회 Response DTO에서 `createdAt` 삭제
- 판매 내역 Response DTO 변경
- 상품 등록 시 valid 설정
  - 제목 공백 불가 및 최대 60자
  - 내용 공백 불가 및 최대 3000자
  - 이미지 최대 10장
- 관심 목록 Response DTO 변경
- 관심 목록 `getter` 메서드 생성
  - 아직 안 하신 것 같아서 리팩토링 하는 김에 같이 했는데 혹시나 하셨다면 말씀해주세요!

<br>

## 테스트코드
![image](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/bf1b5ec1-5ad0-4d8b-ab1a-4df31dc5bdb7)
기존 테스트코드에서 redis가 필요한 부분을 제외한 코드는 모두 통과하였습니다.
DTO 변경 후 테스트코드를 변경하지 않았는데도 통과한 걸 보면 DTO 테스트코드를 보완해야 할 것 같아요...ㅎㅎ...😢

<br>

## Considerations
현재 Auth 에러(비밀번호 암호화 관련 이슈) 때문에 포스트맨 확인은 못했습니다.
우선 테스트코드는 정상적으로 통과되어 PR 날립니다.
비밀번호 부분이 추가되면 바로 확인해보겠습니다.

## Next
**주중 완료 목표**

- 기능 구현
  - Redis를 이용한 조회수 증가
  - 부족한 테스트코드 채우기
 - 리팩토링
  - 예외 처리 `GlobalHandler` 빼기

this closes #66 