### PR TITLE
예외처리 리팩토링 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/request/ItemPostRequest.java
@@ -30,7 +30,7 @@ public class ItemPostRequest {
 	@Length(max = 3000, message = "내용은 최대 3000자 입니다")
 	private String content;
 
-	@Size(max = 10, message = "상품 이미지는 최대 10개까지 등록할 수 있습니다")
+	@Size(max = 10, message = "상품 이미지 등록 수가 최대 제한을 초과했습니다. 상품 등록 요청이 거부되었습니다")
 	private List<Long> imageIds;
 
 	@NotNull(message = "상품 카테고리가 선택되지 않았습니다")

--- a/src/main/java/com/codesquad/secondhand/api/service/image/ImageService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/image/ImageService.java
@@ -19,7 +19,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.image.ImageRepository;
 import com.codesquad.secondhand.exception.image.EmptyFileException;
-import com.codesquad.secondhand.exception.image.FailedUploadException;
+import com.codesquad.secondhand.exception.image.ExceedMaxSizeException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -63,7 +63,7 @@ public class ImageService {
 				new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), objectMetadata)
 					.withCannedAcl(CannedAccessControlList.PublicRead));
 		} catch (IOException e) {
-			throw new FailedUploadException();
+			throw new ExceedMaxSizeException();
 		}
 
 		return amazonS3Client.getUrl(bucket, fileName).toString();

--- a/src/main/java/com/codesquad/secondhand/exception/CustomException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.codesquad.secondhand.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public CustomException(ErrorResponse errorResponse) {
+        this.httpStatus = errorResponse.getHttpStatus();
+        this.message = errorResponse.getMessage();
+    }
+}

--- a/src/main/java/com/codesquad/secondhand/exception/ErrorResponse.java
+++ b/src/main/java/com/codesquad/secondhand/exception/ErrorResponse.java
@@ -1,0 +1,63 @@
+package com.codesquad.secondhand.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorResponse {
+
+    // Category
+    NO_SUCH_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다"),
+
+    // Region
+    NO_SUCH_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 동네입니다"),
+
+    // Item
+    NO_SUCH_ITEM_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품입니다"),
+
+    // Auth
+    EXPIRED_TOKEN_EXCEPTION(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다"),
+    INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    PERMISSION_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "해당 유저는 권한이 없습니다"),
+    SIGN_IN_FAILED_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 다릅니다"),
+    UNAUTHORIZED_USER_EXCEPTION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다"),
+
+    // User
+    DUPLICATED_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
+    DUPLICATED_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다"),
+    NO_SUCH_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다"),
+
+    // UserRegion
+    DUPLICATED_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 동네입니다"),
+    EXCEED_USER_REGION_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST, "동네 등록 수가 최대 제한을 초과했습니다. 동네 등록 요청이 거부되었습니다"),
+    MINIMUM_USER_REGION_VIOLATION_EXCEPTION(HttpStatus.BAD_REQUEST, "최소 1개의 동네는 필수입니다. 동네 삭제 요청이 거부되었습니다"),
+    NO_SUCH_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "나의 동네에 등록 되지 않았습니다"),
+
+    // Image
+    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 비어있거나 없습니다"),
+    EXCEED_MAX_SIZE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 사이즈를 초과하였습니다"),
+    INVALID_EXTENSION_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 이미지 타입이 아닙니다"),
+    NO_SUCH_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 이미지가 없습니다"),
+
+    // ItemImage
+    NO_SUCH_ITEM_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품 이미지입니다"),
+
+    // Status
+    NO_SUCH_STATUS_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 판매 상태입니다"),
+
+    // Wishlist
+    DUPLICATED_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 관심 목록에 등록된 상품입니다"),
+    NO_SUCH_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 상품이 관심 목록에 없습니다"),
+
+    // Provider
+    NO_SUCH_PROVIDER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 공급자입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+    ErrorResponse(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -1,0 +1,58 @@
+package com.codesquad.secondhand.exception;
+
+import com.codesquad.secondhand.api.ApiResponse;
+import com.codesquad.secondhand.exception.auth.ExpiredTokenException;
+import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
+import com.codesquad.secondhand.exception.auth.SignInFailedException;
+import com.codesquad.secondhand.exception.auth.UnauthorizedUserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Void> handleMethodValidException(MethodArgumentNotValidException exception) {
+        LOGGER.error("MethodArgumentNotValidException : ", exception);
+        String message = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(". "));
+
+        return ApiResponse.noData(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<Void> handleCustomException(CustomException exception) {
+        LOGGER.error("CustomException : ", exception);
+        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler({SignInFailedException.class, UnauthorizedUserException.class, PermissionDeniedException.class})
+    public ApiResponse<Void> handleUnauthorizedException(CustomException exception) {
+        LOGGER.error("UnauthorizedException : ", exception);
+        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(ExpiredTokenException.class)
+    public ApiResponse<Void> handleForbiddenException(CustomException exception) {
+        LOGGER.error("ForbiddenException : ", exception);
+        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+    }
+
+}

--- a/src/main/java/com/codesquad/secondhand/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/ExpiredTokenException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.auth;
 
-public class ExpiredTokenException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "Access Token이 만료되었습니다";
+public class ExpiredTokenException extends CustomException {
 
 	public ExpiredTokenException() {
-		super(MESSAGE);
+		super(ErrorResponse.EXPIRED_TOKEN_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/InvalidTokenException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.auth;
 
-public class InvalidTokenException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "유효하지 않은 토큰입니다";
+public class InvalidTokenException extends CustomException {
 
 	public InvalidTokenException() {
-		super(MESSAGE);
+		super(ErrorResponse.INVALID_TOKEN_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/auth/PermissionDeniedException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/PermissionDeniedException.java
@@ -1,10 +1,11 @@
 package com.codesquad.secondhand.exception.auth;
 
-public class PermissionDeniedException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "허가되지 않은 접근입니다";
+public class PermissionDeniedException extends CustomException {
 
 	public PermissionDeniedException() {
-		super(MESSAGE);
+		super(ErrorResponse.PERMISSION_DENIED_EXCEPTION);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/auth/SignInFailedException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/SignInFailedException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.auth;
 
-public class SignInFailedException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "이메일 또는 비밀번호가 일치하지 않습니다";
+public class SignInFailedException extends CustomException {
 
 	public SignInFailedException() {
-		super(MESSAGE);
+		super(ErrorResponse.SIGN_IN_FAILED_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/auth/UnauthorizedUserException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/auth/UnauthorizedUserException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.auth;
 
-public class UnauthorizedUserException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "인증되지 않은 사용자입니다";
+public class UnauthorizedUserException extends CustomException {
 
 	public UnauthorizedUserException() {
-		super(MESSAGE);
+		super(ErrorResponse.UNAUTHORIZED_USER_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/category/NoSuchCategoryException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/category/NoSuchCategoryException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.category;
 
-public class NoSuchCategoryException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "존재하지 않는 카테고리입니다";
+public class NoSuchCategoryException extends CustomException {
 
 	public NoSuchCategoryException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_CATEGORY_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/image/EmptyFileException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/image/EmptyFileException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.image;
 
-public class EmptyFileException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "파일이 비어있습니다";
+public class EmptyFileException extends CustomException {
 
 	public EmptyFileException() {
-		super(MESSAGE);
+		super(ErrorResponse.EMPTY_FILE_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/image/ExceedMaxSizeException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/image/ExceedMaxSizeException.java
@@ -3,10 +3,10 @@ package com.codesquad.secondhand.exception.image;
 import com.codesquad.secondhand.exception.CustomException;
 import com.codesquad.secondhand.exception.ErrorResponse;
 
-public class InvalidExtensionException extends CustomException {
+public class ExceedMaxSizeException extends CustomException {
 
-	public InvalidExtensionException() {
-		super(ErrorResponse.INVALID_EXTENSION_EXCEPTION);
+	public ExceedMaxSizeException() {
+		super(ErrorResponse.EXCEED_MAX_SIZE_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/image/NoSuchImageException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/image/NoSuchImageException.java
@@ -1,10 +1,11 @@
 package com.codesquad.secondhand.exception.image;
 
-public class NoSuchImageException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private final static String MESSAGE = "존재하지 않는 이미지입니다";
+public class NoSuchImageException extends CustomException {
 
 	public NoSuchImageException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_IMAGE_EXCEPTION);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/item/NoSuchItemException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item/NoSuchItemException.java
@@ -1,10 +1,11 @@
 package com.codesquad.secondhand.exception.item;
 
-public class NoSuchItemException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "존재하지 않는 상품입니다";
+public class NoSuchItemException extends CustomException {
 
 	public NoSuchItemException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_ITEM_EXCEPTION);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/item_image/NoSuchItemImageException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/item_image/NoSuchItemImageException.java
@@ -1,9 +1,11 @@
 package com.codesquad.secondhand.exception.item_image;
 
-public class NoSuchItemImageException extends RuntimeException {
-	private final static String MESSAGE = "존재하지 않는 상품 이미지입니다";
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
+
+public class NoSuchItemImageException extends CustomException {
 
 	public NoSuchItemImageException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_ITEM_IMAGE_EXCEPTION);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/region/NoSuchRegionException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/region/NoSuchRegionException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.region;
 
-public class NoSuchRegionException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "존재하지 않는 동네입니다";
+public class NoSuchRegionException extends CustomException {
 
 	public NoSuchRegionException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_REGION_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/status/NoSuchStatusException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/status/NoSuchStatusException.java
@@ -1,10 +1,11 @@
 package com.codesquad.secondhand.exception.status;
 
-public class NoSuchStatusException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "존재하지 않는 상품 상태입니다";
+public class NoSuchStatusException extends CustomException {
 
 	public NoSuchStatusException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_STATUS_EXCEPTION);
 	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedEmailException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedEmailException.java
@@ -1,10 +1,12 @@
 package com.codesquad.secondhand.exception.user;
 
-public class DuplicatedEmailException extends RuntimeException {
-	private static final String MESSAGE = "이미 존재하는 이메일입니다";
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	public DuplicatedEmailException() {
-		super(MESSAGE);
-	}
+public class DuplicatedEmailException extends CustomException {
+
+    public DuplicatedEmailException() {
+        super(ErrorResponse.DUPLICATED_EMAIL_EXCEPTION);
+    }
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedNicknameException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedNicknameException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user;
 
-public class DuplicatedNicknameException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "이미 존재하는 닉네임입니다";
+public class DuplicatedNicknameException extends CustomException {
 
 	public DuplicatedNicknameException() {
-		super(MESSAGE);
+		super(ErrorResponse.DUPLICATED_NICKNAME_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user/NoSuchUserException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user/NoSuchUserException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user;
 
-public class NoSuchUserException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "존재하지 않는 사용자입니다";
+public class NoSuchUserException extends CustomException {
 
 	public NoSuchUserException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_USER_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user_region/DuplicatedUserRegionException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user_region/DuplicatedUserRegionException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user_region;
 
-public class DuplicatedUserRegionException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "이미 등록된 동네입니다";
+public class DuplicatedUserRegionException extends CustomException {
 
 	public DuplicatedUserRegionException() {
-		super(MESSAGE);
+		super(ErrorResponse.DUPLICATED_USER_REGION_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user_region/ExceedUserRegionLimitException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user_region/ExceedUserRegionLimitException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user_region;
 
-public class ExceedUserRegionLimitException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "동네 등록 수가 최대 제한을 초과했습니다";
+public class ExceedUserRegionLimitException extends CustomException {
 
 	public ExceedUserRegionLimitException() {
-		super(MESSAGE);
+		super(ErrorResponse.EXCEED_USER_REGION_LIMIT_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user_region/MinimumUserRegionViolationException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user_region/MinimumUserRegionViolationException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user_region;
 
-public class MinimumUserRegionViolationException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "최소 1개의 동네는 필수입니다";
+public class MinimumUserRegionViolationException extends CustomException {
 
 	public MinimumUserRegionViolationException() {
-		super(MESSAGE);
+		super(ErrorResponse.MINIMUM_USER_REGION_VIOLATION_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user_region/NoSuchUserRegionException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user_region/NoSuchUserRegionException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.user_region;
 
-public class NoSuchUserRegionException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "사용자 동네 목록에 없는 동네입니다";
+public class NoSuchUserRegionException extends CustomException {
 
 	public NoSuchUserRegionException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_USER_REGION_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/wishlist/DuplicatedWishlistException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/wishlist/DuplicatedWishlistException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.wishlist;
 
-public class DuplicatedWishlistException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "이미 관심 목록에 담은 상품입니다";
+public class DuplicatedWishlistException extends CustomException {
 
 	public DuplicatedWishlistException() {
-		super(MESSAGE);
+		super(ErrorResponse.DUPLICATED_WISHLIST_EXCEPTION);
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/wishlist/NoSuchWishlistException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/wishlist/NoSuchWishlistException.java
@@ -1,11 +1,12 @@
 package com.codesquad.secondhand.exception.wishlist;
 
-public class NoSuchWishlistException extends RuntimeException {
+import com.codesquad.secondhand.exception.CustomException;
+import com.codesquad.secondhand.exception.ErrorResponse;
 
-	private static final String MESSAGE = "관심 목록에 없는 상품입니다";
+public class NoSuchWishlistException extends CustomException {
 
 	public NoSuchWishlistException() {
-		super(MESSAGE);
+		super(ErrorResponse.NO_SUCH_WISHLIST_EXCEPTION);
 	}
 
 }

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -70,7 +70,7 @@ public class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.data.price").doesNotExist())
 			.andExpect(jsonPath("$.data.category").value("가전"))
 			.andExpect(jsonPath("$.data.seller.id").value(1L))
-			.andExpect(jsonPath("$.data.seller.nickName").value("nickname"))
+			.andExpect(jsonPath("$.data.seller.nickname").value("nickname"))
 			.andExpect(jsonPath("$.data.numChat").value(0))
 			.andExpect(jsonPath("$.data.numLikes").value(0))
 			.andExpect(jsonPath("$.data.numViews").value(0L))

--- a/src/test/java/com/codesquad/secondhand/api/service/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/auth/jwt/JwtServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import com.codesquad.secondhand.exception.ErrorResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -84,8 +85,7 @@ class JwtServiceTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> jwtService.parse("Bearer " + expiredToken))
 					.isInstanceOf(ExpiredTokenException.class)
-					.hasMessage("Access Token이 만료되었습니다");
-
+					.hasMessage(ErrorResponse.EXPIRED_TOKEN_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("변조된 Access Token을 받았을 때 예외가 발생한다.", () -> {
 				// given
@@ -104,7 +104,7 @@ class JwtServiceTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> jwtService.parse("Bearer " + invalidToken))
 					.isInstanceOf(InvalidTokenException.class)
-					.hasMessage("유효하지 않은 토큰입니다");
+					.hasMessage(ErrorResponse.INVALID_TOKEN_EXCEPTION.getMessage());
 			})
 		);
 	}

--- a/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
@@ -7,6 +7,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 
+import com.codesquad.secondhand.exception.ErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -181,7 +182,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.postItem(request, wrongUserId))
 			.isInstanceOf(NoSuchUserException.class)
-			.hasMessage("존재하지 않는 사용자입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_USER_EXCEPTION.getMessage());
 
 	}
 
@@ -196,7 +197,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.postItem(request, loginUser.getId()))
 			.isInstanceOf(NoSuchCategoryException.class)
-			.hasMessage("존재하지 않는 카테고리입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_CATEGORY_EXCEPTION.getMessage());
 	}
 
 	@DisplayName("상품 등록 시 존재하지 않는 지역을 설정하면 예외가 발생한다.")
@@ -210,7 +211,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.postItem(request, loginUser.getId()))
 			.isInstanceOf(NoSuchRegionException.class)
-			.hasMessage("존재하지 않는 동네입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_REGION_EXCEPTION.getMessage());
 	}
 
 	@DisplayName("상품 등록 시 나의 동네가 아닌 지역을 설정하면 예외가 발생한다.")
@@ -224,7 +225,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.postItem(request, loginUser.getId()))
 			.isInstanceOf(NoSuchUserRegionException.class)
-			.hasMessage("사용자 동네 목록에 없는 동네입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_USER_REGION_EXCEPTION.getMessage());
 	}
 
 	@DisplayName("상품 상세 조회를 성공한다.")
@@ -266,7 +267,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.getItemDetail(wrongItemId, loginUser.getId()))
 			.isInstanceOf(NoSuchItemException.class)
-			.hasMessage("존재하지 않는 상품입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_ITEM_EXCEPTION.getMessage());
 	}
 
 	@DisplayName("상품 삭제를 성공한다.")
@@ -382,7 +383,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> itemService.updateItemStatus(request, loginUser.getId()))
 			.isInstanceOf(PermissionDeniedException.class)
-			.hasMessage("허가되지 않은 접근입니다");
+			.hasMessage(ErrorResponse.PERMISSION_DENIED_EXCEPTION.getMessage());
 	}
 
 }

--- a/src/test/java/com/codesquad/secondhand/api/service/user/UserServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/user/UserServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Collection;
 import java.util.List;
 
+import com.codesquad.secondhand.exception.ErrorResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -79,7 +80,7 @@ class UserServiceTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> userService.createUser(request))
 					.isInstanceOf(DuplicatedEmailException.class)
-					.hasMessage("이미 존재하는 이메일입니다");
+					.hasMessage(ErrorResponse.DUPLICATED_EMAIL_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("이미 사용 중인 닉네임으로 등록을 시도하는 경우 예외가 발생한다.", () -> {
 				// given
@@ -90,7 +91,7 @@ class UserServiceTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> userService.createUser(request))
 					.isInstanceOf(DuplicatedNicknameException.class)
-					.hasMessage("이미 존재하는 닉네임입니다");
+					.hasMessage(ErrorResponse.DUPLICATED_NICKNAME_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("닉네임과 이메일이 중복되지 않는 새로운 사용자 등록에 성공한다.", () -> {
 				// given

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -1,18 +1,5 @@
 package com.codesquad.secondhand.domain.item;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Collection;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
 import com.codesquad.secondhand.domain.category.Category;
@@ -25,8 +12,18 @@ import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.exception.ErrorResponse;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class ItemTest extends IntegrationTestSupport {
 
@@ -93,7 +90,7 @@ public class ItemTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> newItem.removeItemImage(itemImages.get(0)))
 					.isInstanceOf(NoSuchItemImageException.class)
-					.hasMessage("존재하지 않는 상품 이미지입니다");
+					.hasMessage(ErrorResponse.NO_SUCH_ITEM_IMAGE_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("현재 상품의 이미지가 아닌 다른 이미지를 삭제하는 경우 예외가 발생한다.", () -> {
 				// given
@@ -102,7 +99,7 @@ public class ItemTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> newItem.removeItemImage(otherImage.get(0)))
 					.isInstanceOf(NoSuchItemImageException.class)
-					.hasMessage("존재하지 않는 상품 이미지입니다");
+					.hasMessage(ErrorResponse.NO_SUCH_ITEM_IMAGE_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("상품 이미지를 삭제할 수 있다.", () -> {
 				// when
@@ -139,7 +136,7 @@ public class ItemTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> otherItem.delete(loginUser.getId()))
 					.isInstanceOf(PermissionDeniedException.class)
-					.hasMessage("허가되지 않은 접근입니다");
+					.hasMessage(ErrorResponse.PERMISSION_DENIED_EXCEPTION.getMessage());
 			})
 		);
 	}
@@ -225,7 +222,7 @@ public class ItemTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> myItem.updateStatus(otherUser.getId(), status))
 					.isInstanceOf(PermissionDeniedException.class)
-					.hasMessage("허가되지 않은 접근입니다");
+					.hasMessage(ErrorResponse.PERMISSION_DENIED_EXCEPTION.getMessage());
 			})
 		);
 	}

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserRegionTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserRegionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.Collection;
 import java.util.List;
 
+import com.codesquad.secondhand.exception.ErrorResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -45,7 +46,7 @@ class UserRegionTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> user.addUserRegion(region))
 					.isInstanceOf(DuplicatedUserRegionException.class)
-					.hasMessage("이미 등록된 동네입니다");
+					.hasMessage(ErrorResponse.DUPLICATED_USER_REGION_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("사용자 동네를 추가할 수 있다.", () -> {
 				// given
@@ -64,7 +65,7 @@ class UserRegionTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> user.addUserRegion(region))
 					.isInstanceOf(ExceedUserRegionLimitException.class)
-					.hasMessage("동네 등록 수가 최대 제한을 초과했습니다");
+					.hasMessage(ErrorResponse.EXCEED_USER_REGION_LIMIT_EXCEPTION.getMessage());
 			})
 		);
 	}
@@ -87,7 +88,7 @@ class UserRegionTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> user.removeUserRegion(region))
 					.isInstanceOf(NoSuchUserRegionException.class)
-					.hasMessage("사용자 동네 목록에 없는 동네입니다");
+					.hasMessage(ErrorResponse.NO_SUCH_USER_REGION_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("사용자 동네를 삭제할 수 있다.", () -> {
 				// given
@@ -106,7 +107,7 @@ class UserRegionTest extends IntegrationTestSupport {
 				// when // then
 				assertThatThrownBy(() -> user.removeUserRegion(region))
 					.isInstanceOf(MinimumUserRegionViolationException.class)
-					.hasMessage("최소 1개의 동네는 필수입니다");
+					.hasMessage(ErrorResponse.MINIMUM_USER_REGION_VIOLATION_EXCEPTION.getMessage());
 			})
 		);
 	}
@@ -130,7 +131,7 @@ class UserRegionTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> savedUser.updateSelectedRegion(regions.get(1)))
 					.isInstanceOf(NoSuchUserRegionException.class)
-					.hasMessage("사용자 동네 목록에 없는 동네입니다");
+					.hasMessage(ErrorResponse.NO_SUCH_USER_REGION_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("사용자 목록에 있는 동네를 선택할 수 있다.", () -> {
 				// given

--- a/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/user/UserTest.java
@@ -1,19 +1,5 @@
 package com.codesquad.secondhand.domain.user;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Collection;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
 import com.codesquad.secondhand.domain.category.Category;
@@ -27,9 +13,24 @@ import com.codesquad.secondhand.domain.region.RegionRepository;
 import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.wishlist.WishlistRepository;
+import com.codesquad.secondhand.exception.ErrorResponse;
 import com.codesquad.secondhand.exception.user_region.NoSuchUserRegionException;
 import com.codesquad.secondhand.exception.wishlist.DuplicatedWishlistException;
 import com.codesquad.secondhand.exception.wishlist.NoSuchWishlistException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class UserTest extends IntegrationTestSupport {
 
@@ -109,7 +110,7 @@ public class UserTest extends IntegrationTestSupport {
 
 		assertThatThrownBy(() -> seller.validateHasRegion(region))
 			.isInstanceOf(NoSuchUserRegionException.class)
-			.hasMessage("사용자 동네 목록에 없는 동네입니다");
+			.hasMessage(ErrorResponse.NO_SUCH_USER_REGION_EXCEPTION.getMessage());
 	}
 
 	@DisplayName("사용자 관심 목록 시나리오")
@@ -120,7 +121,7 @@ public class UserTest extends IntegrationTestSupport {
 		regionRepository.saveAll(regions);
 
 		User user = FixtureFactory.createUserFixture(List.of(regions.get(0)));
-		User savedUser = userRepository.save(user);
+		userRepository.save(user);
 
 		List<Category> categories = FixtureFactory.createCategoryFixtures(3);
 		categoryRepository.saveAll(categories);
@@ -145,7 +146,7 @@ public class UserTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> user.addWishlist(items.get(0)))
 					.isInstanceOf(DuplicatedWishlistException.class)
-					.hasMessage("이미 관심 목록에 담은 상품입니다");
+					.hasMessage(ErrorResponse.DUPLICATED_WISHLIST_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("중복되지 않은 상품을 관심 목록에 등록하는데 성공한다.", () -> {
 				// when
@@ -165,7 +166,7 @@ public class UserTest extends IntegrationTestSupport {
 				// when & then
 				assertThatThrownBy(() -> user.removeWishlist(items.get(1)))
 					.isInstanceOf(NoSuchWishlistException.class)
-					.hasMessage("관심 목록에 없는 상품입니다");
+					.hasMessage(ErrorResponse.NO_SUCH_WISHLIST_EXCEPTION.getMessage());
 			}),
 			DynamicTest.dynamicTest("아이템을 삭제하면 관심 목록에서도 삭제된다.", () -> {
 				// given


### PR DESCRIPTION
## Description
- `@Valid` 어노테이션 예외 응답 형태 리팩토링
- ExceptionHandler를 하나의 GlobalExceptionHandler로 처리하도록 리팩토링
- 예외 상태 코드와 메세지는 enum으로 관리하도록 리팩토링
- 리팩토링 관련된 테스트코드 수정 반영

## PostMan
- `@Valid` 어노테이션 예외 응답
![스크린샷 2023-09-18 오후 3 46 52](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/77ef453c-ccc1-402a-91fc-1a0c85da0b54)
  - 모든 필드 값이 조건을 지키지 않은 경우 모든 메세지 반환하도록 설정

다른 예외는 스크린샷 생략하겠습니다.
혹시 이상한 부분 있으면 말씀해주세요.

this closes #67 