### PR TITLE
코드 수정 사항 및 프론트엔드 피드백 반영

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/ItemController.java
@@ -2,6 +2,8 @@ package com.codesquad.secondhand.api.controller.item;
 
 import javax.validation.Valid;
 
+import com.codesquad.secondhand.api.controller.item.response.ItemPostResponse;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -50,10 +52,11 @@ public class ItemController {
 
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
-	public ApiResponse<Void> postItem(@RequestBody @Valid ItemPostRequest request, @SignIn SignInUser signInUser) {
-		itemService.postItem(request.toService(imageService.findImagesByIds(request.getImageIds())),
-			signInUser.getId());
-		return ApiResponse.noData(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage());
+	public ApiResponse<ItemPostResponse> postItem(@RequestBody @Valid ItemPostRequest request,
+		@SignIn SignInUser signInUser) {
+		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.ITEM_POST_SUCCESS.getMessage(),
+			itemService.postItem(request.toService(imageService.findImagesByIds(request.getImageIds())),
+				signInUser.getId()));
 	}
 
 	@ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemCategoryResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemCategoryResponse.java
@@ -1,0 +1,18 @@
+package com.codesquad.secondhand.api.controller.item.response;
+
+import com.codesquad.secondhand.domain.category.Category;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ItemCategoryResponse {
+
+	private Long id;
+	private String title;
+
+	public static ItemCategoryResponse from(Category category) {
+		return new ItemCategoryResponse(category.getId(), category.getTitle());
+	}
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemDetailResponse.java
@@ -1,16 +1,18 @@
 package com.codesquad.secondhand.api.controller.item.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.codesquad.secondhand.domain.image.Image;
 import com.codesquad.secondhand.domain.item.Item;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public class ItemDetailResponse {
 
 	private Long id;
@@ -19,69 +21,17 @@ public class ItemDetailResponse {
 	private String content;
 	private LocalDateTime updatedAt;
 	private Integer price;
-	private String category;
+	private ItemCategoryResponse category;
 	private ItemSellerResponse seller;
 	private int numChat;
 	private int numLikes;
 	private Long numViews;
-	private boolean isLiked;
+	private Boolean isLiked;
 	private List<Image> images;
-
-	public Long getId() {
-		return id;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
-
-	public Integer getPrice() {
-		return price;
-	}
-
-	public String getCategory() {
-		return category;
-	}
-
-	public ItemSellerResponse getSeller() {
-		return seller;
-	}
-
-	public int getNumChat() {
-		return numChat;
-	}
-
-	public int getNumLikes() {
-		return numLikes;
-	}
-
-	public Long getNumViews() {
-		return numViews;
-	}
-
-	public boolean getIsLiked() {
-		return isLiked;
-	}
-
-	public List<Image> getImages() {
-		return images;
-	}
 
 	public static ItemDetailResponse from(Item item, Long userId) {
 		return new ItemDetailResponse(item.getId(), item.getTitle(), item.getStatus().getType(), item.getContent(),
-			item.getUpdatedAt(), item.getPrice(), item.getCategory().getTitle(),
+			item.getUpdatedAt(), item.getPrice(), ItemCategoryResponse.from(item.getCategory()),
 			ItemSellerResponse.from(item.getUser()), item.getNumChat(), item.getNumLikes(), item.getViews(),
 			item.isInWishlist(userId), item.listImage());
 	}

--- a/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemPostResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/item/response/ItemPostResponse.java
@@ -1,0 +1,18 @@
+package com.codesquad.secondhand.api.controller.item.response;
+
+import com.codesquad.secondhand.domain.item.Item;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ItemPostResponse {
+
+	private Long id;
+
+	public static ItemPostResponse from(Item item) {
+		return new ItemPostResponse(item.getId());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/controller/user/request/UserCreateRequest.java
+++ b/src/main/java/com/codesquad/secondhand/api/controller/user/request/UserCreateRequest.java
@@ -16,13 +16,15 @@ import lombok.NoArgsConstructor;
 @Getter
 public class UserCreateRequest {
 
-	@Pattern(regexp = "^(?=.*[a-zA-Z가-힣])[a-zA-Z가-힣0-9]{2,10}$", message = "닉네임은 2자 이상 10자 이하, 영문 또는 한글을 포함해야 합니다")
+	@Pattern(regexp = "^(?=.*[a-zA-Z가-힣])[a-zA-Z가-힣0-9]{2,10}$",
+		message = "닉네임은 2자 이상 10자 이하, 영문 또는 한글을 포함해야 합니다")
 	private String nickname;
 
 	@Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식이 올바르지 않습니다")
 	private String email;
 
-	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,16}$", message = "비밀번호는 8자 이상 16자 이하로, 영문, 숫자, 특수문자를 최소 1개씩 포함해야 합니다")
+	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,16}$",
+		message = "비밀번호는 8자 이상 16자 이하로, 영문, 숫자, 특수문자를 최소 1개씩 포함해야 합니다")
 	private String password;
 
 	public UserCreateServiceRequest toService(Image image, Provider provider, Region region) {

--- a/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/ItemService.java
@@ -1,5 +1,6 @@
 package com.codesquad.secondhand.api.service.item;
 
+import com.codesquad.secondhand.api.controller.item.response.ItemPostResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -54,7 +55,7 @@ public class ItemService {
 	}
 
 	@Transactional
-	public void postItem(ItemPostServiceRequest request, Long userId) {
+	public ItemPostResponse postItem(ItemPostServiceRequest request, Long userId) {
 		User seller = userRepository.findById(userId).orElseThrow(NoSuchUserException::new);
 		Region region = regionRepository.findById(request.getRegionId()).orElseThrow(NoSuchRegionException::new);
 		seller.validateHasRegion(region);
@@ -65,6 +66,7 @@ public class ItemService {
 		Item item = request.toEntity(seller, category, region, status);
 		item.addItemImages(request.getImages());
 		itemRepository.save(item);
+		return ItemPostResponse.from(item);
 	}
 
 	// todo : incrementView

--- a/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/item/response/ItemResponse.java
@@ -31,7 +31,7 @@ public class ItemResponse {
 			item.getStatus().getType(),
 			item.getUser().getId(),
 			item.getThumbnailUrl(),
-			item.getCreatedAt(),
+			item.getUpdatedAt(),
 			item.getPrice(),
 			item.getNumChat(),
 			item.getNumLikes()

--- a/src/main/java/com/codesquad/secondhand/api/service/user/response/UserTransactionResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/response/UserTransactionResponse.java
@@ -32,7 +32,7 @@ public class UserTransactionResponse {
 			item.getStatus().getType(),
 			item.getUser().getId(),
 			item.getThumbnailUrl(),
-			item.getCreatedAt(),
+			item.getUpdatedAt(),
 			item.getPrice(),
 			item.getNumChat(),
 			item.getNumLikes()

--- a/src/main/java/com/codesquad/secondhand/domain/item/Item.java
+++ b/src/main/java/com/codesquad/secondhand/domain/item/Item.java
@@ -92,7 +92,7 @@ public class Item extends BaseTimeEntity {
 	}
 
 	public List<Image> listImage() {
-		return detailShot.listAllImages();
+		return detailShot.listAllImages().isEmpty() ? null : detailShot.listAllImages();
 	}
 
 	public int getNumChat() {

--- a/src/main/java/com/codesquad/secondhand/exception/CustomException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/CustomException.java
@@ -1,16 +1,17 @@
 package com.codesquad.secondhand.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-    public CustomException(ErrorResponse errorResponse) {
-        this.httpStatus = errorResponse.getHttpStatus();
-        this.message = errorResponse.getMessage();
-    }
+	public CustomException(ErrorResponse errorResponse) {
+		this.httpStatus = errorResponse.getHttpStatus();
+		this.message = errorResponse.getMessage();
+	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/ErrorResponse.java
+++ b/src/main/java/com/codesquad/secondhand/exception/ErrorResponse.java
@@ -1,63 +1,63 @@
 package com.codesquad.secondhand.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum ErrorResponse {
 
-    // Category
-    NO_SUCH_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다"),
+	// Category
+	NO_SUCH_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다"),
 
-    // Region
-    NO_SUCH_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 동네입니다"),
+	// Region
+	NO_SUCH_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 동네입니다"),
 
-    // Item
-    NO_SUCH_ITEM_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품입니다"),
+	// Item
+	NO_SUCH_ITEM_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품입니다"),
 
-    // Auth
-    EXPIRED_TOKEN_EXCEPTION(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다"),
-    INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
-    PERMISSION_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "해당 유저는 권한이 없습니다"),
-    SIGN_IN_FAILED_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 다릅니다"),
-    UNAUTHORIZED_USER_EXCEPTION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다"),
+	// Auth
+	EXPIRED_TOKEN_EXCEPTION(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다"),
+	INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+	PERMISSION_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "해당 유저는 권한이 없습니다"),
+	SIGN_IN_FAILED_EXCEPTION(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호가 다릅니다"),
+	UNAUTHORIZED_USER_EXCEPTION(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다"),
 
-    // User
-    DUPLICATED_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
-    DUPLICATED_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다"),
-    NO_SUCH_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다"),
+	// User
+	DUPLICATED_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
+	DUPLICATED_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다"),
+	NO_SUCH_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다"),
 
-    // UserRegion
-    DUPLICATED_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 동네입니다"),
-    EXCEED_USER_REGION_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST, "동네 등록 수가 최대 제한을 초과했습니다. 동네 등록 요청이 거부되었습니다"),
-    MINIMUM_USER_REGION_VIOLATION_EXCEPTION(HttpStatus.BAD_REQUEST, "최소 1개의 동네는 필수입니다. 동네 삭제 요청이 거부되었습니다"),
-    NO_SUCH_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "나의 동네에 등록 되지 않았습니다"),
+	// UserRegion
+	DUPLICATED_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 동네입니다"),
+	EXCEED_USER_REGION_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST, "동네 등록 수가 최대 제한을 초과했습니다. 동네 등록 요청이 거부되었습니다"),
+	MINIMUM_USER_REGION_VIOLATION_EXCEPTION(HttpStatus.BAD_REQUEST, "최소 1개의 동네는 필수입니다. 동네 삭제 요청이 거부되었습니다"),
+	NO_SUCH_USER_REGION_EXCEPTION(HttpStatus.BAD_REQUEST, "나의 동네에 등록 되지 않았습니다"),
 
-    // Image
-    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 비어있거나 없습니다"),
-    EXCEED_MAX_SIZE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 사이즈를 초과하였습니다"),
-    INVALID_EXTENSION_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 이미지 타입이 아닙니다"),
-    NO_SUCH_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 이미지가 없습니다"),
+	// Image
+	EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 비어있거나 없습니다"),
+	EXCEED_MAX_SIZE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 사이즈를 초과하였습니다"),
+	INVALID_EXTENSION_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 파일은 이미지 타입이 아닙니다"),
+	NO_SUCH_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 이미지가 없습니다"),
 
-    // ItemImage
-    NO_SUCH_ITEM_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품 이미지입니다"),
+	// ItemImage
+	NO_SUCH_ITEM_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 상품 이미지입니다"),
 
-    // Status
-    NO_SUCH_STATUS_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 판매 상태입니다"),
+	// Status
+	NO_SUCH_STATUS_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 판매 상태입니다"),
 
-    // Wishlist
-    DUPLICATED_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 관심 목록에 등록된 상품입니다"),
-    NO_SUCH_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 상품이 관심 목록에 없습니다"),
+	// Wishlist
+	DUPLICATED_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 관심 목록에 등록된 상품입니다"),
+	NO_SUCH_WISHLIST_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 상품이 관심 목록에 없습니다"),
 
-    // Provider
-    NO_SUCH_PROVIDER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 공급자입니다");
+	// Provider
+	NO_SUCH_PROVIDER_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 공급자입니다");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
-
-    ErrorResponse(HttpStatus httpStatus, String message) {
-        this.httpStatus = httpStatus;
-        this.message = message;
-    }
+	ErrorResponse(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
 }

--- a/src/main/java/com/codesquad/secondhand/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codesquad/secondhand/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.codesquad.secondhand.exception.auth.ExpiredTokenException;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.auth.SignInFailedException;
 import com.codesquad.secondhand.exception.auth.UnauthorizedUserException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -19,40 +20,40 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ApiResponse<Void> handleMethodValidException(MethodArgumentNotValidException exception) {
-        LOGGER.error("MethodArgumentNotValidException : ", exception);
-        String message = exception.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(". "));
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ApiResponse<Void> handleMethodValidException(MethodArgumentNotValidException exception) {
+		LOGGER.error("MethodArgumentNotValidException : ", exception);
+		String message = exception.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(FieldError::getDefaultMessage)
+			.collect(Collectors.joining(". "));
 
-        return ApiResponse.noData(HttpStatus.BAD_REQUEST, message);
-    }
+		return ApiResponse.noData(HttpStatus.BAD_REQUEST, message);
+	}
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(CustomException.class)
-    public ApiResponse<Void> handleCustomException(CustomException exception) {
-        LOGGER.error("CustomException : ", exception);
-        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
-    }
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(CustomException.class)
+	public ApiResponse<Void> handleCustomException(CustomException exception) {
+		LOGGER.error("CustomException : ", exception);
+		return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+	}
 
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler({SignInFailedException.class, UnauthorizedUserException.class, PermissionDeniedException.class})
-    public ApiResponse<Void> handleUnauthorizedException(CustomException exception) {
-        LOGGER.error("UnauthorizedException : ", exception);
-        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
-    }
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler({SignInFailedException.class, UnauthorizedUserException.class, PermissionDeniedException.class})
+	public ApiResponse<Void> handleUnauthorizedException(CustomException exception) {
+		LOGGER.error("UnauthorizedException : ", exception);
+		return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+	}
 
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    @ExceptionHandler(ExpiredTokenException.class)
-    public ApiResponse<Void> handleForbiddenException(CustomException exception) {
-        LOGGER.error("ForbiddenException : ", exception);
-        return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
-    }
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	@ExceptionHandler(ExpiredTokenException.class)
+	public ApiResponse<Void> handleForbiddenException(CustomException exception) {
+		LOGGER.error("ForbiddenException : ", exception);
+		return ApiResponse.noData(exception.getHttpStatus(), exception.getMessage());
+	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedEmailException.java
+++ b/src/main/java/com/codesquad/secondhand/exception/user/DuplicatedEmailException.java
@@ -5,8 +5,8 @@ import com.codesquad.secondhand.exception.ErrorResponse;
 
 public class DuplicatedEmailException extends CustomException {
 
-    public DuplicatedEmailException() {
-        super(ErrorResponse.DUPLICATED_EMAIL_EXCEPTION);
-    }
+	public DuplicatedEmailException() {
+		super(ErrorResponse.DUPLICATED_EMAIL_EXCEPTION);
+	}
 
 }

--- a/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/controller/item/ItemControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 
 import com.codesquad.secondhand.ControllerTestSupport;
 import com.codesquad.secondhand.api.controller.item.request.ItemPostRequest;
+import com.codesquad.secondhand.api.controller.item.response.ItemCategoryResponse;
 import com.codesquad.secondhand.api.controller.item.response.ItemDetailResponse;
 import com.codesquad.secondhand.api.controller.item.response.ItemSellerResponse;
 import com.codesquad.secondhand.domain.image.Image;
@@ -53,8 +54,9 @@ public class ItemControllerTest extends ControllerTestSupport {
 		mockingJwtService();
 		Long itemId = 1L;
 		ItemSellerResponse sellerResponse = new ItemSellerResponse(1L, "nickname");
+		ItemCategoryResponse categoryResponse = new ItemCategoryResponse(2L, "가전");
 		ItemDetailResponse itemResponse = new ItemDetailResponse(1L, "title", "판매중", "content", LocalDateTime.now(),
-			null, "가전", sellerResponse, 0, 0, 0L, false, null);
+			null, categoryResponse, sellerResponse, 0, 0, 0L, false, null);
 
 		when(itemService.getItemDetail(anyLong(), anyLong())).thenReturn(itemResponse);
 
@@ -68,7 +70,8 @@ public class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.data.title").value("title"))
 			.andExpect(jsonPath("$.data.content").value("content"))
 			.andExpect(jsonPath("$.data.price").doesNotExist())
-			.andExpect(jsonPath("$.data.category").value("가전"))
+			.andExpect(jsonPath("$.data.category.id").value(2L))
+			.andExpect(jsonPath("$.data.category.title").value("가전"))
 			.andExpect(jsonPath("$.data.seller.id").value(1L))
 			.andExpect(jsonPath("$.data.seller.nickname").value("nickname"))
 			.andExpect(jsonPath("$.data.numChat").value(0))

--- a/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
+++ b/src/test/java/com/codesquad/secondhand/api/service/item/ItemServiceTest.java
@@ -7,7 +7,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 
-import com.codesquad.secondhand.exception.ErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -36,6 +35,7 @@ import com.codesquad.secondhand.domain.status.Status;
 import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.user.UserRepository;
+import com.codesquad.secondhand.exception.ErrorResponse;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.category.NoSuchCategoryException;
 import com.codesquad.secondhand.exception.item.NoSuchItemException;
@@ -249,7 +249,8 @@ public class ItemServiceTest extends IntegrationTestSupport {
 			() -> assertThat(postedItem.getUpdatedAt()).isCloseTo(item.getUpdatedAt(),
 				within(1, ChronoUnit.SECONDS)),
 			() -> assertThat(postedItem.getPrice()).isNull(),
-			() -> assertThat(postedItem.getCategory()).isEqualTo(categories.get(0).getTitle()),
+			() -> assertThat(postedItem.getCategory().getId()).isEqualTo(categories.get(0).getId()),
+			() -> assertThat(postedItem.getCategory().getTitle()).isEqualTo(categories.get(0).getTitle()),
 			() -> assertThat(postedItem.getSeller().getId()).isEqualTo(seller.getId()),
 			() -> assertThat(postedItem.getNumChat()).isEqualTo(0),
 			() -> assertThat(postedItem.getNumLikes()).isEqualTo(0),
@@ -302,8 +303,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 	@TestFactory
 	Collection<DynamicTest> updateItem() {
 		// given
-		Item myItem = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0),
-			statusList.get(0));
+		Item myItem = FixtureFactory.createItemFixture(loginUser, categories.get(0), regions.get(0), statusList.get(0));
 		itemRepository.save(myItem);
 		myItem.addItemImages(images);
 
@@ -322,7 +322,7 @@ public class ItemServiceTest extends IntegrationTestSupport {
 					() -> assertThat(updatedItem.getTitle()).isEqualTo("new title"),
 					() -> assertThat(updatedItem.getPrice()).isEqualTo(100),
 					() -> assertThat(updatedItem.getContent()).isEqualTo("new content"),
-					() -> assertThat(updatedItem.listImage()).isEmpty(),
+					() -> assertThat(updatedItem.listImage()).isNull(),
 					() -> assertThat(updatedItem.getCategory().getId()).isEqualTo(1L),
 					() -> assertThat(updatedItem.getRegion().getId()).isEqualTo(1L)
 				);

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -15,6 +15,7 @@ import com.codesquad.secondhand.domain.user.UserRepository;
 import com.codesquad.secondhand.exception.ErrorResponse;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
+++ b/src/test/java/com/codesquad/secondhand/domain/item/ItemTest.java
@@ -1,5 +1,18 @@
 package com.codesquad.secondhand.domain.item;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.codesquad.secondhand.FixtureFactory;
 import com.codesquad.secondhand.IntegrationTestSupport;
 import com.codesquad.secondhand.domain.category.Category;
@@ -15,16 +28,6 @@ import com.codesquad.secondhand.domain.user.UserRepository;
 import com.codesquad.secondhand.exception.ErrorResponse;
 import com.codesquad.secondhand.exception.auth.PermissionDeniedException;
 import com.codesquad.secondhand.exception.item_image.NoSuchItemImageException;
-
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Collection;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class ItemTest extends IntegrationTestSupport {
 
@@ -169,7 +172,7 @@ public class ItemTest extends IntegrationTestSupport {
 					() -> assertThat(myItem.getTitle()).isEqualTo("new Title"),
 					() -> assertThat(myItem.getContent()).isEqualTo("new Content"),
 					() -> assertThat(myItem.getPrice()).isEqualTo(100),
-					() -> assertThat(myItem.listImage()).isEmpty()
+					() -> assertThat(myItem.listImage()).isNull()
 				);
 			}),
 			DynamicTest.dynamicTest("새로운 내용 및 새로운 이미지가 반영되도록 수정한다.", () -> {


### PR DESCRIPTION
## Decription
- itemResponse `getCreatedAt` -> `getUpdatedAt` 수정
- 상품 상세 조회 시 이미지 빈 리스트 반환 -> null 반환 수정
- 상품 상세 조회 시 카테고리 이름과 함께 id도 반환하도록 수정
- 상품 등록 시 id 반환하도록 수정

## Test
![스크린샷 2023-09-19 오전 1 09 44](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/a5b4a282-17a5-42d3-afaf-3515a414010b)


## PostMan
1. 상품 상세 조회
![스크린샷 2023-09-19 오전 1 10 54](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/fcb920d7-6cf1-48f7-8d7b-f783082967e2)
- 이미지 없는 경우 null 반환
- 카테고리 이름 함께 반환

<br>

2. 상품 등록
![스크린샷 2023-09-19 오전 1 13 03](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/9ff23983-4a08-466b-83d4-c2da066099a0)
- id 반환

## Considerations
- 새리 피드백 논의 필요
  - status 검증 추가 여부
  - duplicatedWishlist 검증 여부
  - 이미지 경로를 받을 때 enum 타입으로 처리할 것인지

this closes #75 