### PR TITLE
사용자 관심 목록 조회 응답 형태 수정

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistCategory.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistCategory.java
@@ -1,0 +1,19 @@
+package com.codesquad.secondhand.api.service.wishlist.response;
+
+import com.codesquad.secondhand.domain.category.Category;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WishlistCategory {
+
+	private Long id;
+	private String title;
+
+	public static WishlistCategory from(Category category) {
+		return new WishlistCategory(category.getId(), category.getTitle());
+	}
+
+}

--- a/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/wishlist/response/WishlistResponse.java
@@ -19,6 +19,7 @@ public class WishlistResponse {
 	private String status;
 	private Long sellerId;
 	private String thumbnailUrl;
+	private WishlistCategory category;
 	private LocalDateTime updatedAt;
 	private Integer price;
 	private int numChat;
@@ -32,6 +33,7 @@ public class WishlistResponse {
 			wishlist.getItemStatusType(),
 			wishlist.getItemSellerId(),
 			wishlist.getItemThumbnailUrl(),
+			WishlistCategory.from(wishlist.getItem().getCategory()),
 			wishlist.getItemUpdatedAt(),
 			wishlist.getItemPrice(),
 			wishlist.getItemNumChat(),

--- a/src/main/java/com/codesquad/secondhand/domain/wishlist/WishlistRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/wishlist/WishlistRepository.java
@@ -12,6 +12,7 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 		+ "LEFT JOIN fetch w.item AS wi "
 		+ "JOIN fetch wi.region "
 		+ "JOIN fetch wi.status "
+		+ "JOIN fetch wi.category "
 		+ "LEFT JOIN fetch wi.detailShot.itemImages "
 		+ "WHERE w.user.id = :userId "
 		+ "AND wi.isDeleted = false")


### PR DESCRIPTION
## Description

사용자 관심 목록 조회 시 카테고리 정보를 함께 응답합니다.

<img width="536" src="https://github.com/second-hand-team-04/second-hand-max-be-a/assets/105152276/c8f96dc1-519d-4d02-82bf-3cd709a93ff9">

## Consideration

관심 목록 조회 시 현재 Select 문이 3번 나가고 있는데 추후에 리팩토링이 필요해 보입니다.

Closes #77 