### PR TITLE
상품 판매 상태 검증 기능 추가 완료

### DIFF
--- a/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
@@ -90,12 +90,18 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public ItemTransactionSliceResponse findUserTransactionList(Long userId, List<Long> statusIds, Pageable pageable) {
-		if (!statusRepository.existsByIdIn(statusIds)) {
-			throw new NoSuchStatusException();
+		if (statusIds != null && !statusIds.isEmpty()) {
+			validStatus(statusIds);
 		}
 		Slice<Item> responses = queryItemRepository.filteredByUserIdAndStatusIds(userId, statusIds, pageable);
 		return new ItemTransactionSliceResponse(responses.hasNext(),
 			ItemTransactionResponse.from(responses.getContent()));
+	}
+
+	private void validStatus(List<Long> statusIds) {
+		if (!statusRepository.existsByIdIn(statusIds)) {
+			throw new NoSuchStatusException();
+		}
 	}
 
 }

--- a/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
+++ b/src/main/java/com/codesquad/secondhand/api/service/user/UserService.java
@@ -17,9 +17,11 @@ import com.codesquad.secondhand.domain.item.Item;
 import com.codesquad.secondhand.domain.item.QueryItemRepository;
 import com.codesquad.secondhand.domain.provider.Provider;
 import com.codesquad.secondhand.domain.region.Region;
+import com.codesquad.secondhand.domain.status.StatusRepository;
 import com.codesquad.secondhand.domain.user.User;
 import com.codesquad.secondhand.domain.user.UserRepository;
 import com.codesquad.secondhand.exception.auth.SignInFailedException;
+import com.codesquad.secondhand.exception.status.NoSuchStatusException;
 import com.codesquad.secondhand.exception.user.DuplicatedEmailException;
 import com.codesquad.secondhand.exception.user.DuplicatedNicknameException;
 import com.codesquad.secondhand.exception.user.NoSuchUserException;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final StatusRepository statusRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final QueryItemRepository queryItemRepository;
 
@@ -85,11 +88,12 @@ public class UserService {
 				Region.ofDefault())));
 	}
 
-	// todo : 존재하지 않는 statusId에 대한 valid 넣을지 말지 결정
 	@Transactional(readOnly = true)
 	public ItemTransactionSliceResponse findUserTransactionList(Long userId, List<Long> statusIds, Pageable pageable) {
+		if (!statusRepository.existsByIdIn(statusIds)) {
+			throw new NoSuchStatusException();
+		}
 		Slice<Item> responses = queryItemRepository.filteredByUserIdAndStatusIds(userId, statusIds, pageable);
-
 		return new ItemTransactionSliceResponse(responses.hasNext(),
 			ItemTransactionResponse.from(responses.getContent()));
 	}

--- a/src/main/java/com/codesquad/secondhand/domain/status/StatusRepository.java
+++ b/src/main/java/com/codesquad/secondhand/domain/status/StatusRepository.java
@@ -1,6 +1,11 @@
 package com.codesquad.secondhand.domain.status;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StatusRepository extends JpaRepository<Status, Long> {
+
+	boolean existsByIdIn(List<Long> statusIds);
+
 }


### PR DESCRIPTION
## Description
- 사용자의 판매 내역 조회 시 상품 판매 상태를 선택할 때 해당 상태 id가 존재하는지 검증 기능 추가
  - id가 2개 이상인 경우 하나라도 값이 존재하면 예외를 발생시키지 않습니다. 이 경우 정상적인 판매 상태에 속하는 상품을 반환하도록 하였습니다.

## PostMan
- `statusId` 2개 중 2개 모두 존재하지 않는 경우
![스크린샷 2023-09-21 오전 12 50 36](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/e7a4f3da-61cf-442f-881a-d47142b547e1)

<br>

- `statusId` 2개 중 하나가 존재하는 경우
![스크린샷 2023-09-21 오전 12 50 52](https://github.com/second-hand-team-04/second-hand-max-be-a/assets/107015624/0f473757-63d4-4626-9413-abd5273ec909)

this closes #78 